### PR TITLE
Handle cycles in require statements of local files

### DIFF
--- a/lib/helpers/dependencies.js
+++ b/lib/helpers/dependencies.js
@@ -62,7 +62,7 @@ function nestedDependencies(pkgName, basedir) {
 
 function recursiveDependencies(code, options) {
     options = options || {};
-    const ignore = options.ignore || [];
+    const ignore = options.ignore || [];
     const basedir = options.basedir || process.cwd();
 
     return Promise.map(detective(code), function(requireStatement) {
@@ -70,7 +70,7 @@ function recursiveDependencies(code, options) {
         const newIgnore = [].concat(ignore);
 
         // Recurse
-        if (_.startsWith(requireStatement, '.') || _.startsWith(requireStatement, '/')) {
+        if (_.startsWith(requireStatement, '.') || _.startsWith(requireStatement, '/')) {
             // Local file, recursively grab all other dependencies
             return pkgInfo(requireStatement, basedir).then(function(pkg) {
                 if (!pkg.path) {

--- a/lib/helpers/dependencies.js
+++ b/lib/helpers/dependencies.js
@@ -53,9 +53,7 @@ function nestedDependencies(pkgName, basedir) {
 
         return Promise.map(names, function(nestedPkgName) {
             return nestedDependencies(nestedPkgName, basedir);
-        }).then(function(results) {
-            return _.compact(results);
-        }).then(function(results) {
+        }).then(_.compact).then(function(results) {
             pkg.dependencies = results;
             return pkg;
         });
@@ -64,17 +62,38 @@ function nestedDependencies(pkgName, basedir) {
 
 function recursiveDependencies(code, options) {
     options = options || {};
+    const ignore = options.ignore || [];
     const basedir = options.basedir || process.cwd();
 
     return Promise.map(detective(code), function(requireStatement) {
-        // Check if local
-        if (_.startsWith(requireStatement, '.') || _.startsWith(requireStatement, '/')) {
+        // Add to the ignore list (the seen list)
+        const newIgnore = [].concat(ignore);
+
+        // Recurse
+        if (_.startsWith(requireStatement, '.') || _.startsWith(requireStatement, '/')) {
+            // Local file, recursively grab all other dependencies
             return pkgInfo(requireStatement, basedir).then(function(pkg) {
+                if (!pkg.path) {
+                    // No path for the package, which is strange, so skip
+                    return [];
+                }
+
+                // If ignored, just return the package itself and not recurse
+                if (newIgnore.indexOf(pkg.path) !== -1) {
+                    return [_.assign({}, pkg, {
+                        duplicate: true
+                    })];
+                }
+
+                // Make sure to ignore going forwards
+                newIgnore.push(pkg.path);
+
                 return fs.readFileAsync(pkg.path).then(function(data) {
                     const checksum = crypto.createHash('sha1').update(data).digest('hex');
 
                     return recursiveDependencies(data, _.assign({}, options, {
-                        basedir: path.dirname(pkg.path)
+                        basedir: path.dirname(pkg.path),
+                        ignore: newIgnore
                     })).then(function(results) {
                         return results.concat(_.assign({}, pkg, {
                             checksum: checksum
@@ -92,8 +111,10 @@ function recursiveDependencies(code, options) {
             });
         }
     }).then(function(results) {
-        return _.union(_.flatten(results)).map(function(result) {
-            return _.pick(result, ['name', 'version', 'path', 'core', 'dependencies', 'checksum']);
+        return _.unionWith(_.flatten(results), function(a, b) {
+            return a.path === b.path;
+        }).map(function(result) {
+            return _.pick(result, ['name', 'version', 'path', 'core', 'dependencies', 'checksum', 'duplicate']);
         });
     });
 }


### PR DESCRIPTION
- [X] Issue exists - Internal Asana
- [X] Linter passes (`npm run lint`)
- [X] Tests pass (`npm run test`)
- [X] CircleCI build is green
- [X] Documentation is up to date (README + comments)

Brief overview of changes:
- Make sure any cyclical references in local files does not cause the manifest generation to go into an infinite loop.