### PR TITLE
Improved documentation and help menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ This repository contains a set of scripts that are useful when developing [AWS L
 Install the tools via npm, this will make the following commands available in the directory that you ran the install command in (optionally, pass in `-g` to install the commands globally).
 
 ```
-npm install lambda-tools -g
+npm install lambda-tools
 ```
 
-## Configuration file
+### Configuration file
 
 All scripts may make use of a `.lambda-tools-rc.json` file in the root of the project (that is, the location of `package.json` that is closest to Lambda functions). This allows defining some meaningful defaults for the scripts, such as a default stage, region and a project name. An example content of said file could be
 
@@ -30,88 +30,22 @@ All scripts may make use of a `.lambda-tools-rc.json` file in the root of the pr
 
 These defaults are used for deployment and running the service locally, which is useful for example when creating dynamic resource names that rely on the stage and project names.
 
-## Setup
+### Expected Service Structure
 
-This step should only ever be run once for AWS account and region combination. The step will create the necessary Lambda function that acts as the CloudFormation resource for all stacks created by lambda-tools. The command assumes that you have configured [AWS CLI](https://aws.amazon.com/cli/) with your credentials and a default region. If no region is defined, `us-east-1` is assumed. **If this step is not done, services with an `api.json` file will fail to deploy.**
-
-```
-lambda setup [-r aws-region-name]
-```
-
-## Deploy
+In order for the scripts to work properly, the following structure is assumed for a service
 
 ```
-lambda deploy -n project-name [-s stage-to-deploy] [-r aws-region-to-deploy-to] [-e environment] [-h]
-```
-
-Deployment of a service to AWS, goes through multiple steps during the process:
-
-1. Locally processes Lambda functions, using [browserify](http://browserify.org) and [uglify](https://github.com/mishoo/UglifyJS) to optimise the performance of the resulting functions
-2. Generates a CloudFormation template that is used to raise/update a stack on AWS
-3. Uploads Lambda function code, API definition (if any) and the compiled CloudFormation template to S3
-4. Creates/Updates the CF stack using the template and assets in S3
-
-## Deploy (Single Lambda)
-
-```
-lambda deploy-single -n function-name -f main.js [-r aws-region-to-deploy-to] [--env environment] [-h]
-```
-
-Deploying a single Lambda function directly to AWS Lambda. Processes the Lambda function as described in `deploy`, thus reducing the size of the function. Doesn't upload the function to S3.
-
-### Caching
-
-Both `deploy` and `deploy-single` implement a caching logic to avoid the costly bundling process of Lambda functions. This cache checks the code by generating a manifest of it (a checksum of the main handler file + a full list of dependencies it requires), if the manifest matches the one that is present from a previous deploy, the resulting ZIP file can be reused. To circumvent this cache, use the `--clean` flag, forcing bundling.
-
-### Authentication
-
-`lambda deploy` and `lambda deploy-single` assume you have configured AWS credentials [that can be reached by the script](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html#Setting_AWS_Credentials). The script uses AWS SDK for Node.js, which is able to automatically pick up credentials from various places, thus, the script itself does not allow modifying/storing credentials.
-
-## Execute
-
-```
-lambda execute [-e event-file] [-t timeout] [--env environment=value,foo=bar] [-h] [lambda-function]
-```
-
-Execute a single Lambda function with specified event, timeout and environment values. The `lambda-function` argument can be specified in multiple ways:
-
-1. As a file path, in which case the file is assumed to be the handler
-2. As a file name, in which case the file is expected to exist in the current directory
-3. If executed inside of a service, `lambda-function` can be the name of the function to execute, i.e the name of the subdirectory in `lambdas`, where the Lambda function is.
-
-In any of these cases, an event file is located as follows:
-
-1. If a file argument was specified, it is checked relative to the location of the Lambda function (the location of the `index.js` being executed)
-2. If the argument is specified, it is checked relative to the current working directory (the location where `lambda execute` is running from)
-3. If neither of those exists, then an empty event is used as a fallback. Similarly, if either file fails to parse as valid JSON.
-
-By default, the event file is assumed to be `event.json` and the timeout is set to 6 seconds. The environment is empty (i.e the running environment is not mirrored).
-
-## Run
-
-```
-lambda run [-p port] [-e environment=value,foo=bar] [-a path-to-api-spec] [-h]
-```
-
-Running a Lambda backed microservice locally. This should be used strictly for development purposes as the code that simulates AWS is imperfect (at best) and is not guaranteed to respond similarly to the actual Lambda environment. It does however do its best to allow locally debugging lambda functions sitting behind an API gateway.
-
-The command starts a local server, which parses the API spec (defaults to `./api.json`) and creates appropriate routes, all invalid routes return `404`. The server also mimics AWS's logic in creating the integration (i.e it maps the incoming HTTP request into an AWS Lambda integration), as well as mapping the result of the Lambda function into an appropriate HTTP response.
-
-### Notes about microservice structure
-
-In order for the scripts to work properly, the following structure is assumed for a microservice
-
-```
-Root Directory of the service
-| api.json  - Swagger definition of the API to expose (optional)
-| cf.json   - CloudFormation template for any additional resources or overrides
-| lambda_policies.json - Additional AWS IAM policies for the Lambda functions (optional)
-| package.json - By default all services are assumed to be NPM packages
-| lambdas   - Directory containing Lambda functions, all subdirectories are treated as a function
-    | lambda_name - Name of the directory is used as the name for the Lambda function
-        | *.js    - JS files making up the Lambda function (default assumes index.js exists)
-        | cf.json - Overrides for properties that are defined on Lambda function (allows overriding default index.js handler)
-    | ...
+.
+├── api.json    - Swagger API definition (optional), used by lambda deploy and run
+├── cf.json     - CloudFormation template, shouldn't include Lambda functions, API Gateway or IAM roles
+├── lambda_policies.json - Additional AWS IAM policies for the Lambda functions (optional)
+├── package.json - By default all services are assumed to be NPM packages
+├── .lambda-tools-rc.json - Configuration file for lambda-tools, can contain default values for scripts to use
+├── lambdas
+│   └── lambda_name
+│       ├── cf.json - Overrides for Lambda function properties (such as memory size or timeout length)
+│       └── index.js - Default entrypoint for Lambda function (can be overriden by specifying handler in cf.json)
+└── package.json
 ```
 
 As all Lambda functions are bundled and compressed during deployment, it is safe to share common code between Lambda functions in the top level of the microservice, for example in a directory called `common` or `lib`. Achieving this structure is easier by using [Yeoman](http://yeoman.io) and the [`generator-lambda-tools` generators](https://www.npmjs.com/package/generator-lambda-tools).
@@ -119,3 +53,106 @@ As all Lambda functions are bundled and compressed during deployment, it is safe
 #### Examples
 
 A minimal example of a service is implemented under [`examples/microservice`](examples/microservice).
+
+### AWS Credentials
+
+All scripts assume that AWS credentials have been configured in a way that is [reachable by the AWS Node.js SDK](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html#Setting_AWS_Credentials). Lamba Tools does not provide a way to provide custom credentials.
+
+#### IAM Permissions
+
+The actions the user executing the scripts should be able to perform are:
+
+1. `setup`
+    1. `iam:GetRole`
+    2. `iam:CreateRole`
+    3. `iam:PutRolePolicy`
+    4. `lambda:GetFunction`
+    5. `lambda:CreateFunction`
+    6. `lambda:UpdateFunctionCode`
+    7. `lambda:UpdateFunctionConfiguration`
+    7. `lambda:GetAlias`
+    8. `lambda:UpdateAlias`
+    9. `lambda:CreateAlias`
+2. `deploy`
+    1. `s3:CreateBucket`
+    2. `s3:PutObject`
+    3. `cloudformation:DescribeStacks`
+    4. `cloudformation:UpdateStack`
+    5. `cloudformation:CreateStack`
+    6. `lambda:*` - Required transitively by CloudFormation for creating the Lambda functions
+    7. `apigateway:*` - Required transitively by CloudFormation for creating API Gateway instance
+    6. \+ any permissions that are required by resources in the CloudFormation template
+3. `deploy-single`
+    1. `lambda:UpdateFunctionCode`
+3. `run`
+    1. N/A
+4. `execute`
+    1. N/A
+
+### Setup
+
+This step should only ever be run once for AWS account and region combination. The step will create the necessary Lambda function that acts as the CloudFormation resource for all stacks created by lambda-tools. If no region is defined, `us-east-1` is assumed. **If this step is not done, services with an `api.json` file will fail to deploy.**
+
+```
+lambda setup [options]
+```
+
+## Deployment
+
+Deploying a service to AWS
+
+```
+lambda deploy [options]
+```
+
+Deployment of a service to AWS, goes through multiple steps during the process:
+
+1. Locally processes Lambda functions, using [browserify](http://browserify.org) and [uglify](https://github.com/mishoo/UglifyJS) to optimise the performance of the resulting functions
+2. Completes the CloudFormation template in `cf.json`. This is used for raising/updating the stack on AWS
+3. Uploads Lambda function code, API definition (if any) and the compiled CloudFormation template to S3
+4. Creates/Updates the CF stack using the template and assets in S3
+
+### Single Lambda
+
+A single Lambda function can be deployed without using CloudFormation via `lambda deploy-single`. This simply updates the Lambda function code. **The script assumes that the Lambda function already exists.**
+
+```
+lambda deploy-single -n function-name [options]
+```
+
+Deploying a single Lambda function directly to AWS Lambda. Processes the Lambda function as described in `deploy`, thus reducing the size of the function. Doesn't upload the function to S3.
+
+### Caching
+
+Both `deploy` and `deploy-single` implement a caching logic to avoid the costly transpiling process of Lambda functions. This cache generates a manifest for the Lambda function by bundling all of its code into a single file and generating a checksum of it. The manifest also includes a dependency tree, which is used for `--exclude`. If the manifest matches the previous deployment, the ZIP file is reused. To circumvent this reuse policy, use the `--clean` flag, which forces a rebundling/transpiling.
+
+
+## Execute
+
+```
+lambda execute [options] lambda-function
+```
+
+Execute a single Lambda function. The `lambda-function` argument can be specified in multiple ways:
+
+1. As a file path, in which case the file is assumed to be the module that exports the `handler` function
+2. As a file name, in which case the file is expected to exist in the current directory
+3. If executed inside of a service, `lambda-function` can be the name of the function to execute, i.e the name of the subdirectory in `lambdas`, where the Lambda function is.
+
+In any of these cases, an event file is located as follows:
+
+1. Relative to the Lambda handler file location, if there is an `event.json` in the same directory
+2. If the `-e` option is used, it is checked relative to the current working directory
+3. If neither of those exists, then an empty event is used as a fallback. Similarly, if either file fails to parse as valid JSON.
+
+By default, the event file is assumed to be `event.json` and the timeout is set to 6 seconds. The environment is empty (i.e the running environment is not mirrored).
+
+## Run
+
+```
+lambda run [options]
+```
+
+Running a service locally. This should be used strictly for development purposes as the code that simulates AWS is imperfect (at best) and is not guaranteed to respond similarly to the actual Lambda environment. It does however do its best to allow locally debugging lambda functions sitting behind an API gateway.
+
+The command starts a local server, which parses the API spec (defaults to `./api.json`) and creates appropriate routes, all invalid routes return `404`. The server also mimics AWS's logic in creating the integration (i.e it maps the incoming HTTP request into an AWS Lambda integration), as well as mapping the result of the Lambda function into an appropriate HTTP response.

--- a/bin/lambda-deploy-single.js
+++ b/bin/lambda-deploy-single.js
@@ -30,7 +30,7 @@ program
     .option('-p, --publish', 'If set publishes a new version of the Lambda function')
     .option('-e, --environment <env>', 'Environment variables to make available in the Lambda function', parseEnvironment, {})
     .option('--dry-run', 'Simply packs the Lambda function into a minified zip')
-    .option('--exclude <list>', 'Packages to exclude from bundling', function(value) { return value.split(','); })
+    .option('--exclude [list]', 'Packages to exclude from bundling', function(value) { return value.split(','); })
     .option('-o, --optimization <level>', 'Optimization level to use, valid values are 0-1', parseInt, 1)
     .option('--clean', 'Force a clean build where cached bundles are not used')
     .option('--no-color', 'Turn off ANSI coloring in output');

--- a/bin/lambda-deploy-single.js
+++ b/bin/lambda-deploy-single.js
@@ -33,8 +33,30 @@ program
     .option('--exclude <list>', 'Packages to exclude from bundling', function(value) { return value.split(','); })
     .option('-o, --optimization <level>', 'Optimization level to use, valid values are 0-1', parseInt, 1)
     .option('--clean', 'Force a clean build where cached bundles are not used')
-    .option('--no-color', 'Turn off ANSI coloring in output')
-    .parse(process.argv);
+    .option('--no-color', 'Turn off ANSI coloring in output');
+
+program.on('--help', function() {
+    console.log();
+    console.log('  Examples:');
+    console.log();
+    console.log('    Deploy function \'hello-world\' from default file (index.js)');
+    console.log('    $ lambda deploy-single -n hello-world');
+    console.log();
+    console.log('    Deploy function \'foo\' with a handler from file \'./diverted.js\'');
+    console.log('    $ lambda deploy-single -n foo -f ./diverted.js');
+    console.log();
+    console.log('    Deploy function \'foo\', also publishing a version');
+    console.log('    $ lambda deploy-single -n foo --publish');
+    console.log();
+    console.log('    Deploy function \'foo\', excluding \'example\' package from bundle (included in ZIP separately)');
+    console.log('    $ lambda deploy-single -n foo --exclude example');
+    console.log();
+    console.log('    Deploy function \'foo\', with NODE_ENV and FOO set and disabling minification');
+    console.log('    $ lambda deploy-single -n foo -e NODE_ENV=production,FOO=bar --optimization 0');
+    console.log();
+});
+
+program.parse(process.argv);
 
 //
 // Configure program

--- a/bin/lambda-deploy-single.js
+++ b/bin/lambda-deploy-single.js
@@ -24,7 +24,7 @@ const updateLambdas = require('../lib/deploy/update-lambdas-step');
 
 program
     .description('Deploy code to a single Lambda function')
-    .option('-n, --function-name <name>', 'Function name')
+    .usage('[options] <function-name>')
     .option('-f, --file <file>', 'Lambda file location', './index.js')
     .option('-r, --region <region>', 'AWS region to work in')
     .option('-p, --publish', 'If set publishes a new version of the Lambda function')
@@ -40,19 +40,19 @@ program.on('--help', function() {
     console.log('  Examples:');
     console.log();
     console.log('    Deploy function \'hello-world\' from default file (index.js)');
-    console.log('    $ lambda deploy-single -n hello-world');
+    console.log('    $ lambda deploy-single hello-world');
     console.log();
     console.log('    Deploy function \'foo\' with a handler from file \'./diverted.js\'');
-    console.log('    $ lambda deploy-single -n foo -f ./diverted.js');
+    console.log('    $ lambda deploy-single foo -f ./diverted.js');
     console.log();
     console.log('    Deploy function \'foo\', also publishing a version');
-    console.log('    $ lambda deploy-single -n foo --publish');
+    console.log('    $ lambda deploy-single foo --publish');
     console.log();
     console.log('    Deploy function \'foo\', excluding \'example\' package from bundle (included in ZIP separately)');
-    console.log('    $ lambda deploy-single -n foo --exclude example');
+    console.log('    $ lambda deploy-single foo --exclude example');
     console.log();
     console.log('    Deploy function \'foo\', with NODE_ENV and FOO set and disabling minification');
-    console.log('    $ lambda deploy-single -n foo -e NODE_ENV=production,FOO=bar --optimization 0');
+    console.log('    $ lambda deploy-single foo -e NODE_ENV=production,FOO=bar --optimization 0');
     console.log();
 });
 
@@ -66,6 +66,7 @@ program.parse(process.argv);
 chalk.enabled = program.color;
 
 // Determine function name
+program.functionName = program.args[0];
 program.functionName = program.functionName || prompt.question('Please enter the name of the function you are deploying: ');
 
 // Make region global for AWS

--- a/bin/lambda-deploy.js
+++ b/bin/lambda-deploy.js
@@ -34,8 +34,26 @@ program
     .option('--exclude <list>', 'Packages to exclude from bundling', function(val) { return val.split(','); })
     .option('-o, --optimization <level>', 'Optimization level to use, valid values are 0-1', parseInt, 1)
     .option('--clean', 'Force a clean build where cached bundles are not used')
-    .option('--no-color', 'Turn off ANSI coloring in output')
-    .parse(process.argv);
+    .option('--no-color', 'Turn off ANSI coloring in output');
+
+program.on('--help', function() {
+    console.log('  Examples:');
+    console.log();
+    console.log('    Generate deployment files (in staging directory), but don\'t actually deploy');
+    console.log('    $ lambda deploy --dry-run');
+    console.log();
+    console.log('    Deploy to \'prod\' stage with NODE_ENV set to \'production\' and FOO set to \'bar\'')
+    console.log('    $ lambda deploy -s prod -e NODE_ENV=production,FOO=bar');
+    console.log();
+    console.log('    Deploy to default (dev) stage excluding \'example\' package from the bundle (included in the ZIP separately)');
+    console.log('    $ lambda deploy --exclude example');
+    console.log();
+    console.log('    Deploy to default stage, ignoring cached bundles and disabling minification');
+    console.log('    $ lambda deploy --clean --optimization 0');
+    console.log();
+});
+
+program.parse(process.argv);
 
 //
 // Configure program

--- a/bin/lambda-deploy.js
+++ b/bin/lambda-deploy.js
@@ -37,6 +37,7 @@ program
     .option('--no-color', 'Turn off ANSI coloring in output');
 
 program.on('--help', function() {
+    console.log();
     console.log('  Examples:');
     console.log();
     console.log('    Generate deployment files (in staging directory), but don\'t actually deploy');

--- a/bin/lambda-deploy.js
+++ b/bin/lambda-deploy.js
@@ -31,7 +31,7 @@ program
     .option('-r, --region <region>', 'Region')
     .option('-e, --environment <env>', 'Environment Variables to embed as key-value pairs', parseEnvironment, {})
     .option('--dry-run', 'Simply generate files that would be used to update the stack and API')
-    .option('--exclude <list>', 'Packages to exclude from bundling', function(val) { return val.split(','); })
+    .option('--exclude [list]', 'Packages to exclude from bundling', function(val) { return val.split(','); })
     .option('-o, --optimization <level>', 'Optimization level to use, valid values are 0-1', parseInt, 1)
     .option('--clean', 'Force a clean build where cached bundles are not used')
     .option('--no-color', 'Turn off ANSI coloring in output');

--- a/bin/lambda-deploy.js
+++ b/bin/lambda-deploy.js
@@ -42,7 +42,7 @@ program.on('--help', function() {
     console.log('    Generate deployment files (in staging directory), but don\'t actually deploy');
     console.log('    $ lambda deploy --dry-run');
     console.log();
-    console.log('    Deploy to \'prod\' stage with NODE_ENV set to \'production\' and FOO set to \'bar\'')
+    console.log('    Deploy to \'prod\' stage with NODE_ENV set to \'production\' and FOO set to \'bar\'');
     console.log('    $ lambda deploy -s prod -e NODE_ENV=production,FOO=bar');
     console.log();
     console.log('    Deploy to default (dev) stage excluding \'example\' package from the bundle (included in the ZIP separately)');

--- a/bin/lambda-execute.js
+++ b/bin/lambda-execute.js
@@ -22,8 +22,30 @@ program
     .option('-e, --event <file>', 'Path to the event JSON file, defaults to \'event.json\'', parsePath, 'event.json')
     .option('--env, --environment <env>', 'Environment Variables to embed as key-value pairs', parseEnvironment, {})
     .option('-t, --timeout <timeout>', 'Timeout value for the Lambda function', 6)
-    .option('--no-color', 'Turn off ANSI coloring in output')
-    .parse(process.argv);
+    .option('--no-color', 'Turn off ANSI coloring in output');
+
+program.on('--help', function() {
+    console.log();
+    console.log('  Examples:');
+    console.log();
+    console.log('    Execute function from file index.js with the default event');
+    console.log('    $ lambda execute ./index.js');
+    console.log();
+    console.log('    Exceute function named \'foo\' from current service');
+    console.log('    $ lambda execute foo');
+    console.log();
+    console.log('    Execute function \'foo\' from current service with specific event file');
+    console.log('    $ lambda execute foo -e ../event.json');
+    console.log();
+    console.log('    Execute function from index.js with environment variables NODE_ENV and FOO set');
+    console.log('    $ lambda execute index.js --env NODE_ENV=test,FOO=bar');
+    console.log();
+    console.log('    Execute function \'foo\' with a custom timeout of 60s');
+    console.log('    $ lambda execute foo -t 60');
+    console.log();
+});
+
+program.parse(process.argv);
 
 // Enable/Disable colors
 chalk.enabled = program.color;

--- a/bin/lambda-run.js
+++ b/bin/lambda-run.js
@@ -30,8 +30,27 @@ program
     .option('-a, --api-file <file>', 'Path to Swagger API spec (defaults to "./api.json")', parsePath, path.resolve(cwd, 'api.json'))
     .option('-e, --environment <env>', 'Environment Variables to embed as key-value pairs', parseEnvironment, {})
     .option('--mirror-environment', 'Mirror the environment visible to lambda-tools in the lambda functions')
-    .option('--no-color', 'Turn off ANSI coloring in output')
-    .parse(process.argv);
+    .option('--no-color', 'Turn off ANSI coloring in output');
+
+program.on('--help', function() {
+    console.log();
+    console.log('  Examples:');
+    console.log();
+    console.log('    Run service from api.json on port 3000 with no environment variables specified');
+    console.log('    $ lambda run');
+    console.log();
+    console.log('    Run service on port 80');
+    console.log('    $ lambda run -p 80');
+    console.log();
+    console.log('    Run service from specific Swagger file and with environment variables NODE_ENV and FOO set');
+    console.log('    $ lambda run -a different_api.json -e NODE_ENV=test,FOO=bar');
+    console.log();
+    console.log('    Run service mirroring current process\' environment variables to Lambda functions');
+    console.log('    $ lambda run --mirror-environment');
+    console.log();
+});
+
+program.parse(process.argv);
 
 // Enable/Disable colors
 chalk.enabled = program.color;


### PR DESCRIPTION
- [X] Issue exists - #27 
- [X] Linter passes (`npm run lint`)
- [X] Tests pass (`npm run test`)
- [X] CircleCI build is green
- [X] Documentation is up to date (README + comments)

Brief overview of changes:
- Updated the `--help` menus of all commands to include example usages
- Updated README to include more information about IAM permissioning
- Updated README to use a better structure
- Updated README for each command, discarding all options from the example signatures
- Updated the calling signature of `lambda deploy-single` to use the first argument as the function-name, as it is required