### PR TITLE
Avoid looping recursion in dependencies calculation

### DIFF
--- a/lib/helpers/dependencies.js
+++ b/lib/helpers/dependencies.js
@@ -46,13 +46,30 @@ function pkgInfo(id, basedir) {
     });
 }
 
-function nestedDependencies(pkgName, basedir) {
+function nestedDependencies(pkgName, basedir, ignore) {
+    ignore = ignore || [];
+
     return pkgInfo(pkgName, basedir)
     .then(function(pkg) {
-        const names = _.keys(pkg.dependencies);
+        const skip = ignore.indexOf({
+            name: pkg.name,
+            version: pkg.version
+        }) !== -1;
 
-        return Promise.map(names, function(nestedPkgName) {
-            return nestedDependencies(nestedPkgName, basedir);
+        if (skip) {
+            return pkg;
+        }
+
+        const deps = pkg.dependencies;
+
+        // Add ourselves to ignore list (cuts cyclical loops)
+        const newIgnore = ignore.concat({
+            name: pkg.name,
+            version: pkg.version
+        });
+
+        return Promise.map(_.keys(deps), function(nestedPkgName) {
+            return nestedDependencies(nestedPkgName, basedir, newIgnore);
         }).then(_.compact).then(function(results) {
             pkg.dependencies = results;
             return pkg;

--- a/lib/helpers/dependencies.js
+++ b/lib/helpers/dependencies.js
@@ -51,11 +51,11 @@ function nestedDependencies(pkgName, basedir, ignore) {
 
     return pkgInfo(pkgName, basedir)
     .then(function(pkg) {
-        const skip = ignore.indexOf({
+        const skip = _.findIndex(ignore, {
             name: pkg.name,
             version: pkg.version
         }) !== -1;
-
+        
         if (skip) {
             return pkg;
         }

--- a/lib/helpers/dependencies.js
+++ b/lib/helpers/dependencies.js
@@ -47,7 +47,7 @@ function pkgInfo(id, basedir) {
 }
 
 function nestedDependencies(pkgName, basedir, ignore) {
-    ignore = ignore || [];
+    ignore = ignore || [];
 
     return pkgInfo(pkgName, basedir)
     .then(function(pkg) {


### PR DESCRIPTION
- [X] Issue exists - Internal
- [X] Linter passes (`npm run lint`)
- [X] Tests pass (`npm run test`)
- [X] CircleCI build is green
- [X] Documentation is up to date (README + comments)

Brief overview of changes:
- Updated the way the manifest is calculated, making sure circular dependencies do not cause problems