### PR TITLE
Handle mock routes in lambda run

### DIFF
--- a/lib/run/responder.js
+++ b/lib/run/responder.js
@@ -65,10 +65,10 @@ module.exports = function *(apiDefinition, result) {
                 }
 
                 // Set the resulting value to the header
-                headers[key] = value;
+                headers[key] = _.trim(value, '\'');
             } else {
                 // Set as a constant
-                headers[key] = value;
+                headers[key] = _.trim(value, '\'');
             }
         });
     }

--- a/lib/run/route.js
+++ b/lib/run/route.js
@@ -71,7 +71,7 @@ function lambdaRoute(apiDefinition, program) {
     };
 }
 
-function mockRoute(apiDefinition, program) {
+function mockRoute(apiDefinition) {
     return function *() {
         // Final step is to map the result back to a response
         console.log(chalk.gray('\t--'), 'Creating mock response');
@@ -90,14 +90,14 @@ function mockRoute(apiDefinition, program) {
 module.exports = function(apiDefinition, program) {
     // Handle the route based on the configuration
     if (apiDefinition.type === 'mock') {
-        return mockRoute(apiDefinition, program);
+        return mockRoute(apiDefinition);
     } else if (apiDefinition.type === 'aws') {
         // Lambda function
         return lambdaRoute(apiDefinition, program);
     } else {
         return function *() {
             // Ignore, but log out
-            console.log('Unhandled API Gateway integration type', parsedPath, '=>', configuration.type);
+            console.log('Unhandled API Gateway integration type', apiDefinition.type);
         };
     }
 };

--- a/lib/run/route.js
+++ b/lib/run/route.js
@@ -10,11 +10,7 @@ const Responder = require('./responder');
 
 const fsx = require('../helpers/fs-additions');
 
-//
-//  Route handler middleware
-//
-
-module.exports = function(apiDefinition, program) {
+function lambdaRoute(apiDefinition, program) {
     return function *() {
         // Derive the Lambda function file path (ignoring whether it exists or not)
         let lambdaPath = _.get(apiDefinition, 'uri');
@@ -73,4 +69,35 @@ module.exports = function(apiDefinition, program) {
         this.response.body = response.body;
         this.set(response.headers);
     };
+}
+
+function mockRoute(apiDefinition, program) {
+    return function *() {
+        // Final step is to map the result back to a response
+        console.log(chalk.gray('\t--'), 'Creating mock response');
+        const response = yield Responder.bind(this, apiDefinition, '{}');
+        this.response.status = response.status;
+        this.response.type = response.type;
+        this.response.body = response.body;
+        this.set(response.headers);
+    };
+}
+
+//
+//  Route handler middleware
+//
+
+module.exports = function(apiDefinition, program) {
+    // Handle the route based on the configuration
+    if (apiDefinition.type === 'mock') {
+        return mockRoute(apiDefinition, program);
+    } else if (apiDefinition.type === 'aws') {
+        // Lambda function
+        return lambdaRoute(apiDefinition, program);
+    } else {
+        return function *() {
+            // Ignore, but log out
+            console.log('Unhandled API Gateway integration type', parsedPath, '=>', configuration.type);
+        };
+    }
 };


### PR DESCRIPTION
- [X] Issue exists - Internal Asana
- [X] Linter passes (`npm run lint`)
- [X] Tests pass (`npm run test`)
- [X] CircleCI build is green
- [X] Documentation is up to date (README + comments)

Brief overview of changes:
- Updated `lambda run` to also handle mock integrations in the API definition. These are useful for CORS support.
- Made sure that only integrations of type `aws` are treated as Lambda functions.