### PR TITLE
Default Node.js runtime support

### DIFF
--- a/lib/deploy/bundle-lambdas-step.js
+++ b/lib/deploy/bundle-lambdas-step.js
@@ -2,18 +2,21 @@
 
 const Promise = require('bluebird');
 const archive = require('simple-archiver').archive;
-const babelify = require('babelify');
-const presets = require('babel-preset-es2015');
-const Browserify = require('browserify');
-const crypto = require('crypto');
-const envify = require('envify/custom');
 const fs = Promise.promisifyAll(require('graceful-fs'));
-const fsx = require('../helpers/fs-additions');
-const path = require('path');
-const uglify = require('uglify-js');
 const _ = require('lodash');
 
+const fsx = require('../helpers/fs-additions');
 const getDependencies = require('../helpers/dependencies');
+
+const path = require('path');
+const crypto = require('crypto');
+
+const babelify = require('babelify');
+const es2015presets = require('babel-preset-es2015');
+const node4presets = require('babel-preset-es2015-node4');
+const Browserify = require('browserify');
+const envify = require('envify/custom');
+const uglify = require('uglify-js');
 
 // Optimization levels, higher number gets
 // everything from the levels below + adds something
@@ -63,6 +66,8 @@ function archiveDependencies(cwd, pkg) {
  *  @param lambda Lambda function to bundle, should at minimum have a path property
  *                 with the entry point
  *  @param exclude Array of packages to exclude from the bundle, defaults to aws-sdk
+ *  @param environment Env variables to envify
+ *  @param transpile Babelify options (.presets), if undefined then not transpiled
  *
  *  @returns Promise that resolves to the bundled code
  */
@@ -94,14 +99,16 @@ function bundleLambda(lambda, exclude, environment, transpile) {
 
         // Envify (doesn't purge, as there are valid values
         // that can be used in Lambda functions)
-        bundler.transform(envify(environment), {
-            global: true
-        });
+        if (environment) {
+            bundler.transform(envify(environment), {
+                global: true
+            });
+        }
 
+        // Babel (for ES6 support)
         if (transpile) {
-            // Babel (for ES6 support)
             bundler.transform(babelify, {
-                presets: [presets],
+                presets: transpile.presets,
                 compact: false,
                 global: true,
                 ignore: /\/node_modules\/\.bin\/.*/
@@ -170,7 +177,7 @@ module.exports = function(context) {
                 return context.logger.task(lambda.name, function(resolve, reject) {
                     // First, bundle the code
                     logger.task('Bundling', function(res, rej) {
-                        bundleLambda(lambda, excluded, env, false)
+                        bundleLambda(lambda, excluded, env)
                         .then(res, rej);
                     })
                     .then(function(bundledCode) {
@@ -178,9 +185,14 @@ module.exports = function(context) {
                         return logger.task('Generate manifest', function(res, rej) {
                             fs.readFileAsync(lambda.path).then(function(originalCode) {
                                 return getDependencies(originalCode, { basedir: path.dirname(lambda.path), deep: true }).then(function(dependencies) {
+                                    const config = {
+                                        runtime: _.get(lambda, 'config.Properties.Runtime')
+                                    };
+
                                     return {
                                         checksum: crypto.createHash('sha1').update(bundledCode).digest('hex'),
-                                        dependencies: dependencies
+                                        dependencies: dependencies,
+                                        config: config
                                     };
                                 });
                             })
@@ -212,7 +224,19 @@ module.exports = function(context) {
 
                             // Re-process the bundle
                             return logger.task('Rebundling/Transpiling', function(res, rej) {
-                                bundleLambda(lambda, excluded, env, true)
+                                // Determine appropriate transpiler presets
+                                const runtime = _.get(lambda, 'config.Properties.Runtime');
+                                let options;
+
+                                if (runtime === 'nodejs') {
+                                    // 0.10 runtime
+                                    options = { presets: [es2015presets] };
+                                } else if (runtime === 'nodejs4.3') {
+                                    // Node 4.3 runtime
+                                    options = { presets: [node4presets] };
+                                }
+
+                                bundleLambda(lambda, excluded, env, options)
                                 .then(function(code) {
                                     // Write to disk (again)
                                     return fs.writeFileAsync(bundledPath, code).then(function() {

--- a/lib/deploy/derive-stack-step.js
+++ b/lib/deploy/derive-stack-step.js
@@ -48,28 +48,15 @@ function loadLambdas(result) {
     }
 
     // Add Lambdas
-    const lambdaConfigurationTemplate = fsx.readJSONFileSync(path.join(context.directories.root, 'templates/lambda.cf.json'));
     const lambdaOutputTemplate = dot.template(fs.readFileSync(path.join(context.directories.root, 'templates/lambda.resource.dot'), 'utf8'));
 
     context.lambdas.forEach(function(lambda) {
         let camelName = _.camelCase(lambda.name);
         camelName = camelName.charAt(0).toUpperCase() + camelName.substring(1);
 
-        // Check if further config exists
-        const template = _.cloneDeep(lambdaConfigurationTemplate);
-
-        if (lambda.config) {
-            _.merge(template, fsx.readJSONFileSync(lambda.config));
-        }
-
-        template['Properties']['Code'] = {
-            'S3Bucket': context.project.bucket,
-            'S3Key': context.project.timestamp + '/' + lambda.name + '.zip'
-        };
-
         const outputName = 'l' + camelName;
         stack['Outputs'][outputName] = JSON.parse(lambdaOutputTemplate({ name: camelName }));
-        stack['Resources'][camelName] = template;
+        stack['Resources'][camelName] = lambda.config;
     });
 
     return {

--- a/lib/deploy/setup-step.js
+++ b/lib/deploy/setup-step.js
@@ -56,7 +56,7 @@ function listLambdas(context) {
         const lambdas = fsx.getDirectories(lambdasDirectory).map(function(lambdaPath) {
             // Extract the name of the lambda (the name of the directory)
             const name = path.basename(lambdaPath);
-            let config = fsx.readJSONFileSync(path.join(context.directories.root, 'templates/lambda.cf.json'));;
+            let config = fsx.readJSONFileSync(path.join(context.directories.root, 'templates/lambda.cf.json'));
 
             // Log out the lambda
             context.logger.log(name);
@@ -79,8 +79,8 @@ function listLambdas(context) {
             }
 
             // Derive the module name and handler function
-            let moduleName = config.Properties.Handler.split('.')[0];
-            let handler = config.Properties.Handler.split('.')[1];
+            const moduleName = config.Properties.Handler.split('.')[0];
+            const handler = config.Properties.Handler.split('.')[1];
 
             // Determine the locations in S3 we will upload the files to
             config['Properties']['Code'] = {

--- a/lib/deploy/setup-step.js
+++ b/lib/deploy/setup-step.js
@@ -54,9 +54,7 @@ function listLambdas(context) {
         const lambdas = fsx.getDirectories(lambdasDirectory).map(function(lambdaPath) {
             // Extract the name of the lambda (the name of the directory)
             const name = path.basename(lambdaPath);
-            let handler = 'handler';
-            let moduleName = 'index';
-            let configPath;
+            let config = fsx.readJSONFileSync(path.join(context.directories.root, 'templates/lambda.cf.json'));;
 
             // Log out the lambda
             context.logger.log(name);
@@ -65,18 +63,26 @@ function listLambdas(context) {
             // handler/module name
             const lambdaCustomCF = path.join(lambdaPath, 'cf.json');
             if (fsx.fileExists(lambdaCustomCF)) {
-                configPath = lambdaCustomCF;
+                const customConfig = fsx.readJSONFileSync(lambdaCustomCF);
 
-                const config = fsx.readJSONFileSync(lambdaCustomCF);
-                const moduleHandler = _.get(config, 'Properties.Handler', `${moduleName}.${handler}`);
-
-                moduleName = moduleHandler.split('.', 1)[0];
-                handler = moduleHandler.split('.', 2)[1];
+                // Merge into config, only picking out the Properties key
+                // to avoid custom config overriding anythign other than that
+                config = _.merge(config, _.pick(customConfig, 'Properties'));
             }
+
+            // Derive the module name and handler function
+            let moduleName = config.Properties.Handler.split('.')[0];
+            let handler = config.Properties.Handler.split('.')[1];
+
+            // Determine the locations in S3 we will upload the files to
+            config['Properties']['Code'] = {
+                'S3Bucket': context.project.bucket,
+                'S3Key': context.project.timestamp + '/' + name + '.zip'
+            };
 
             return {
                 name: name,
-                config: configPath,
+                config: config,
                 module: moduleName,
                 handler: handler,
                 path: path.resolve(lambdaPath, `${moduleName}.js`)
@@ -96,8 +102,8 @@ function listLambdas(context) {
 module.exports = function(context) {
     return context.logger.task('Preparing stage', function(resolve, reject) {
         prepareStagingDirectory(context)
-        .then(listLambdas)
         .then(createS3Bucket)
+        .then(listLambdas)
         .then(resolve, reject);
     });
 };

--- a/lib/deploy/setup-step.js
+++ b/lib/deploy/setup-step.js
@@ -1,10 +1,12 @@
 "use strict";
 
 const AWS = require('aws-sdk');
-const fsx = require('../helpers/fs-additions');
 const path = require('path');
 const _ = require('lodash');
 const os = require('os');
+
+const configuration = require('../helpers/config');
+const fsx = require('../helpers/fs-additions');
 
 function prepareStagingDirectory(context) {
     // Located temp directory for staging (make sure it exists)
@@ -59,8 +61,14 @@ function listLambdas(context) {
             // Log out the lambda
             context.logger.log(name);
 
-            // Check if there is a configuration file, which may contain customised
-            // handler/module name
+            // Update Runtime (if we have a match from configuration)
+            const runtime = _.get(configuration, 'lambda.runtime');
+            if (runtime) {
+                _.set(config, 'Properties.Runtime', runtime);
+            }
+
+            // Check if there is a configuration file, which may override various
+            // properties of the Lambda function
             const lambdaCustomCF = path.join(lambdaPath, 'cf.json');
             if (fsx.fileExists(lambdaCustomCF)) {
                 const customConfig = fsx.readJSONFileSync(lambdaCustomCF);

--- a/lib/deploy/templates/lambda.cf.json
+++ b/lib/deploy/templates/lambda.cf.json
@@ -10,7 +10,7 @@
         },
         "Handler": "index.handler",
         "MemorySize": 256,
-        "Role": {"Fn::GetAtt": ["IamRoleLambda", "Arn"] },
+        "Role": { "Fn::GetAtt": ["IamRoleLambda", "Arn"] },
         "Runtime": "nodejs",
         "Timeout": 6
     }

--- a/lib/helpers/config.js
+++ b/lib/helpers/config.js
@@ -10,8 +10,12 @@ const _ = require('lodash');
  */
 
 // Load configuration file from disk (if one exists)
+// Default values
 let result = {
     project: {},
+    lambda: {
+        runtime: 'nodejs'
+    },
     aws: {
         region: 'us-east-1',
         stage: 'dev'

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "ansi": "^0.3.1",
     "aws-sdk": "^2.2.19",
     "babel-preset-es2015": "^6.1.18",
+    "babel-preset-es2015-node4": "^2.1.0",
     "babelify": "^7.2.0",
     "bluebird": "^3.1.1",
     "browserify": "^12.0.1",
@@ -52,7 +53,7 @@
     "resolve": "^1.1.7",
     "simple-archiver": "^0.1.3",
     "swagger-parser": "^3.3.0",
-    "uglify-js": "^2.6.1",
+    "uglify-js": "mishoo/UglifyJS2#harmony",
     "untildify": "^2.1.0",
     "velocityjs": "^0.7.5"
   },


### PR DESCRIPTION
- [X] Issue exists - #21 
- [X] Linter passes (`npm run lint`)
- [X] Tests pass (`npm run test`)
- [X] CircleCI build is green
- [X] Documentation is up to date (README + comments)

Brief overview of changes:
- Added support for Node.js 4.3 runtime
- Added support for loading the service default runtime from `.lambda-tools-rc.json`
- Added better ES6 support for minification by using the Harmony branch of Uglify-JS
- Reduced the number of Babel transforms ran on code destined for Lambda on Node.js 4.3
- Modified the Lambda manifest generator to also include the runtime