### PR TITLE
Drop uglify-js

### DIFF
--- a/bin/lambda-deploy-single.js
+++ b/bin/lambda-deploy-single.js
@@ -31,7 +31,6 @@ program
     .option('-e, --environment <env>', 'Environment variables to make available in the Lambda function', parseEnvironment, {})
     .option('--dry-run', 'Simply packs the Lambda function into a minified zip')
     .option('--exclude [list]', 'Packages to exclude from bundling', function(value) { return value.split(','); })
-    .option('-o, --optimization <level>', 'Optimization level to use, valid values are 0-1', parseInt, 1)
     .option('--clean', 'Force a clean build where cached bundles are not used')
     .option('--no-color', 'Turn off ANSI coloring in output');
 
@@ -51,8 +50,8 @@ program.on('--help', function() {
     console.log('    Deploy function \'foo\', excluding \'example\' package from bundle (included in ZIP separately)');
     console.log('    $ lambda deploy-single foo --exclude example');
     console.log();
-    console.log('    Deploy function \'foo\', with NODE_ENV and FOO set and disabling minification');
-    console.log('    $ lambda deploy-single foo -e NODE_ENV=production,FOO=bar --optimization 0');
+    console.log('    Deploy function \'foo\', with NODE_ENV and FOO set');
+    console.log('    $ lambda deploy-single foo -e NODE_ENV=production,FOO=bar');
     console.log();
 });
 
@@ -90,7 +89,7 @@ const context = {
         path: lambdaPath
     }],
 
-    program: _.pick(program, ['environment', 'stage', 'region', 'lambda', 'optimization', 'exclude', 'clean']),
+    program: _.pick(program, ['environment', 'stage', 'region', 'lambda', 'exclude', 'clean']),
     logger: logger
 };
 

--- a/bin/lambda-deploy.js
+++ b/bin/lambda-deploy.js
@@ -32,7 +32,6 @@ program
     .option('-e, --environment <env>', 'Environment Variables to embed as key-value pairs', parseEnvironment, {})
     .option('--dry-run', 'Simply generate files that would be used to update the stack and API')
     .option('--exclude [list]', 'Packages to exclude from bundling', function(val) { return val.split(','); })
-    .option('-o, --optimization <level>', 'Optimization level to use, valid values are 0-1', parseInt, 1)
     .option('--clean', 'Force a clean build where cached bundles are not used')
     .option('--no-color', 'Turn off ANSI coloring in output');
 
@@ -49,8 +48,8 @@ program.on('--help', function() {
     console.log('    Deploy to default (dev) stage excluding \'example\' package from the bundle (included in the ZIP separately)');
     console.log('    $ lambda deploy --exclude example');
     console.log();
-    console.log('    Deploy to default stage, ignoring cached bundles and disabling minification');
-    console.log('    $ lambda deploy --clean --optimization 0');
+    console.log('    Deploy to default stage, ignoring cached bundles');
+    console.log('    $ lambda deploy --clean');
     console.log();
 });
 
@@ -92,7 +91,7 @@ const context = {
         timestamp: Math.floor(Date.now() / 1000)
     },
 
-    program: _.pick(program, ['environment', 'stage', 'region', 'lambda', 'optimization', 'exclude', 'clean']),
+    program: _.pick(program, ['environment', 'stage', 'region', 'lambda', 'exclude', 'clean']),
     logger: logger
 };
 

--- a/lib/deploy/bundle-lambdas-step.js
+++ b/lib/deploy/bundle-lambdas-step.js
@@ -16,14 +16,6 @@ const es2015presets = require('babel-preset-es2015');
 const node4presets = require('babel-preset-es2015-node4');
 const Browserify = require('browserify');
 const envify = require('envify/custom');
-const uglify = require('uglify-js');
-
-// Optimization levels, higher number gets
-// everything from the levels below + adds something
-const OPTIMIZATION = {
-    UGLIFIED: 1,
-    BUNDLED: 0
-};
 
 /**
  *  Helper for recursively adding all dependencies to an archive
@@ -109,7 +101,8 @@ function bundleLambda(lambda, exclude, environment, transpile) {
         if (transpile) {
             bundler.transform(babelify, {
                 presets: transpile.presets,
-                compact: false,
+                compact: true,
+                comments: false,
                 global: true,
                 ignore: /\/node_modules\/\.bin\/.*/
             });
@@ -119,29 +112,6 @@ function bundleLambda(lambda, exclude, environment, transpile) {
             if (err) return reject(err);
             resolve(data);
         });
-    });
-}
-
-/**
- *  Minify code using UglifyJS
- *
- *  @param code Code to minify
- *
- *  @returns Promise that resolves to the minified code
- */
-function minifyCode(code) {
-    return new Promise(function(resolve, reject) {
-        const minified = uglify.minify(code, {
-            fromString: true,
-            mangle: false,
-            compress: {}
-        }).code;
-
-        if (!minified) {
-            reject(new Error(`Failed to uglify/minify`));
-        }
-
-        resolve(minified);
     });
 }
 
@@ -155,7 +125,6 @@ module.exports = function(context) {
     const cwd = context.directories.cwd;
 
     const excluded = context.program.exclude;
-    const optimization = context.program.optimization;
     const clean = context.program.clean;
     const logger = context.logger;
     const env = context.program.environment;
@@ -174,6 +143,8 @@ module.exports = function(context) {
                 const zippedPath = path.resolve(context.directories.staging, lambda.name + '.zip');
                 const manifestPath = path.resolve(context.directories.staging, lambda.name + '.manifest.json');
 
+                const runtime = _.get(lambda, 'config.Properties.Runtime');
+
                 return context.logger.task(lambda.name, function(resolve, reject) {
                     // First, bundle the code
                     logger.task('Bundling', function(res, rej) {
@@ -186,7 +157,7 @@ module.exports = function(context) {
                             fs.readFileAsync(lambda.path).then(function(originalCode) {
                                 return getDependencies(originalCode, { basedir: path.dirname(lambda.path), deep: true }).then(function(dependencies) {
                                     const config = {
-                                        runtime: _.get(lambda, 'config.Properties.Runtime')
+                                        runtime: runtime
                                     };
 
                                     return {
@@ -225,7 +196,6 @@ module.exports = function(context) {
                             // Re-process the bundle
                             return logger.task('Rebundling/Transpiling', function(res, rej) {
                                 // Determine appropriate transpiler presets
-                                const runtime = _.get(lambda, 'config.Properties.Runtime');
                                 let options;
 
                                 if (runtime === 'nodejs') {
@@ -244,21 +214,6 @@ module.exports = function(context) {
                                     });
                                 })
                                 .then(res, rej);
-                            })
-                            .then(function(code) {
-                                if (optimization >= OPTIMIZATION.UGLIFIED) {
-                                    return logger.task('Minifying', function(res, rej) {
-                                        minifyCode(code.toString('utf8')).then(function(minified) {
-                                            // Store the minfied code
-                                            return fs.writeFileAsync(minifiedPath, minified)
-                                            .then(function() {
-                                                return minified;
-                                            });
-                                        }).then(res, rej);
-                                    });
-                                }
-
-                                return code;
                             })
                             .then(function(code) {
                                 // Archive the resulting code

--- a/lib/deploy/bundle-lambdas-step.js
+++ b/lib/deploy/bundle-lambdas-step.js
@@ -139,7 +139,6 @@ module.exports = function(context) {
             // Process all lambdas (serially so that we can output nicely)
             return Promise.mapSeries(context.lambdas, function(lambda) {
                 const bundledPath = path.resolve(context.directories.staging, lambda.name + '.bundled.js');
-                const minifiedPath = path.resolve(context.directories.staging, lambda.name + '.minified.js');
                 const zippedPath = path.resolve(context.directories.staging, lambda.name + '.zip');
                 const manifestPath = path.resolve(context.directories.staging, lambda.name + '.manifest.json');
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "resolve": "^1.1.7",
     "simple-archiver": "^0.1.3",
     "swagger-parser": "^3.3.0",
-    "uglify-js": "mishoo/UglifyJS2#harmony",
     "untildify": "^2.1.0",
     "velocityjs": "^0.7.5"
   },


### PR DESCRIPTION
- [X] Issue exists - Internal
- [X] Linter passes (`npm run lint`)
- [X] Tests pass (`npm run test`)
- [X] CircleCI build is green
- [X] Documentation is up to date (README + comments)

Brief overview of changes:
- Removing UglifyJS step from Lambda code bundling
- Enabling compacting and comment dropping for Browserify

The benefit from UglifyJS was negligible, especially when compacting is allowed in browserify, as well as dropping comments. The difference is not worth the additional complexity that would come from having to separately handle ES6 or wait until done so by UglifyJS.