### PR TITLE
Handle local execution with the Lambda callback model

### DIFF
--- a/lib/run/execution-wrapper.js
+++ b/lib/run/execution-wrapper.js
@@ -50,6 +50,7 @@ function wrapper(path, handler, evt, timeout) {
     timeout = parseInt(timeout || 6000, 10);
     handler = handler || 'handler';
     evt = evt || {};
+    let finished = false;
 
     // Timeout monitoring
     const now = new Date().getTime();
@@ -62,7 +63,9 @@ function wrapper(path, handler, evt, timeout) {
 
     // Listen to premature exits
     process.on('beforeExit', function() {
-        context.fail(new Error('Process exited without completing request'));
+        if (!finished) {
+            context.fail(new Error('Process exited without completing request'));
+        }
     });
 
     // Create a context object to pass along to the Lambda function
@@ -84,11 +87,35 @@ function wrapper(path, handler, evt, timeout) {
 
         getRemainingTimeInMillis: function() {
             return deadline - (new Date()).getTime();
-        }
+        },
+
+        callbackWaitsForEmptyEventLoop: true
     };
 
     try {
-        require(path)[handler](evt, context);
+        const fn = require(path)[handler];
+
+        // Detect if it uses the callback pattern or not
+        if (fn.length === 3) {
+            // Callback is used, in our case we will just send out
+            // the result and stop the watchdog, but we will not forcefully
+            // exit the process. This should be similar to how Lambda does it,
+            // where it naturally then let's the process terminate
+            fn(evt, context, function(err, data) {
+                clearTimeout(watchdog);
+                finished = true;
+
+                if (!context.callbackWaitsForEmptyEventLoop) {
+                    // Exit the process as well
+                    exit(err, data);
+                } else {
+                    if (err) sendError(process.pid, err);
+                    sendResult(process.pid, data);
+                }
+            });
+        } else {
+            fn(evt, context);
+        }
     } catch(err) {
         sendError(process.pid, err, function() {
             process.exit(1);


### PR DESCRIPTION
- [X] Issue exists - #21 
- [X] Linter passes (`npm run lint`)
- [X] Tests pass (`npm run test`)
- [X] CircleCI build is green
- [X] Documentation is up to date (README + comments)

Brief overview of changes:
- Make sure `lambda run` and `lambda execute` support the new callback based model in Lambda
- Try to simulate as accurately as possible what AWS does when the callback approach is used, the main exception being that execution does not "finish" early, i.e it does not resolve or reject as soon as it gets a result, and instead waits until the process finishes.
- This should allow for two things. Avoiding complexities that come from potentially having multiple Lambdas running at the same time locally, as well as making the stdout grouping better, as Lambda function output is grouped nicely and is more readable.