### PR TITLE
Adopt a better versioning for our custom Lambda backed CF resources

### DIFF
--- a/lib/api-gateway-resource/index.js
+++ b/lib/api-gateway-resource/index.js
@@ -346,7 +346,7 @@ exports.handler = function(event, context) {
         const stageName = properties.StageName;
         const deploymentId = event.PhysicalResourceId;
 
-        if (stage) {
+        if (stageName) {
             // Remove the stage from the API
             promise = promise.then(function(existing) {
                 if (!existing.id) {

--- a/lib/api-gateway-resource/index.js
+++ b/lib/api-gateway-resource/index.js
@@ -18,7 +18,7 @@ const _ = require('lodash');
 /**
  *  Helper function that downloads an S3 file to a local path
  *
- *  @returns Promise, which resolves to the local path the file was
+ *  @returns {Promise} which resolves to the local path the file was
  *  saved at.
  */
 function downloadFile(bucket, key, version, localPath) {
@@ -61,7 +61,7 @@ function headFile(bucket, key, version) {
 /**
  *  Helper function for replacing variables in the API definition
  *
- *  @returns Promise, which resolves into the same localPath the file was
+ *  @returns {Promise} which resolves into the same localPath the file was
  *  written back to
  */
 function replaceVariables(localPath, variables) {
@@ -94,7 +94,7 @@ function replaceVariables(localPath, variables) {
 /**
  *  Helper function that fetches an existing API by it's name
  *
- *  @returns Promise, which resolves to either null or an existing API
+ *  @returns {Promise} which resolves to either null or an existing API
  */
 function fetchExistingAPI(apiName, position) {
     return new Promise(function(resolve, reject) {
@@ -130,29 +130,37 @@ function fetchExistingAPI(apiName, position) {
 /**
  *  Helper function for deleting an API stage from API Gateway instance
  *
- *  @returns Promise, which resolves to the passed in apiId, if stage was successfully
- *  deleted
+ *  @returns {Promise} which resolves to deleted API stage
  */
-function deleteAPIStage(apiId, stageName) {
+function deleteAPIStage(apiId, stageName, deploymentId) {
     return new Promise(function(resolve, reject) {
-        console.log('Delete API Stage', apiId, stageName);
-
-        APIG.deleteStage({
+        // Validate the stage deletion first (it has to have the
+        // correct deploymentId)
+        APIG.getStage({
             restApiId: apiId,
-            stageName: stageName
-        }, function(err) {
-            console.log('Done', err);
+            stageName:
+        }, function(err, data) {
+            if (err) return reject(err);
+            resolve(data);
+        });
+    }).then(function(stage) {
+        if (stage.deploymentId !== deploymentId) {
+            // We are not going to delete as the stage we are looking for no-longer
+            // exists like we expect it to
+            return {
+                deploymentId: deploymentId,
+                stageName: stageName
+            };
+        }
 
-            if (err) {
-                // If no such stage, then success
-                if (err.code === 404 || err.code === 'NotFoundException') {
-                    return resolve(apiId);
-                }
-
-                return reject(err);
-            }
-
-            resolve(apiId);
+        return new Promise(function(resolve, reject) {
+            APIG.deleteStage({
+                restApiId: apiId,
+                stageName: stageName
+            }, function(err, data) {
+                if (err) return reject(err);
+                resolve(data);
+            });
         });
     });
 }
@@ -160,7 +168,7 @@ function deleteAPIStage(apiId, stageName) {
 /**
  *  Helper function for fetching all stages for an API
  *
- *  @returns Promise, which resolves into a list of stages
+ *  @returns {Promise} which resolves into a list of stages
  */
 function fetchAPIStages(apiId) {
     return new Promise(function(resolve, reject) {
@@ -263,7 +271,18 @@ function updateAPI(existingAPI, apiName, stageName, definitionPath) {
             throw result.error;
         }
 
-        return fetchExistingAPI(apiName);
+        return fetchExistingAPI(apiName).then(function(api) {
+            // Resolve with the deployed stage
+            return new Promise(function(resolve, reject) {
+                APIG.getStage({
+                    restApiId: api.id,
+                    stageName: stageName
+                }, function(err, data) {
+                    if (err) return reject(err);
+                    resolve(data);
+                });
+            });
+        });
     });
 }
 
@@ -324,37 +343,47 @@ exports.handler = function(event, context) {
         // Deleting is slightly more complex
         // We need to either simply delete a stage, or delete both the stage
         // as well as the API Gateway instance itself
-        const stage = properties.StageName;
+        const stageName = properties.StageName;
+        const deploymentId = event.PhysicalResourceId;
 
         if (stage) {
             // Remove the stage from the API
             promise = promise.then(function(existing) {
                 if (!existing.id) {
                     // Nothing to delete
-                    return existing;
+                    return {
+                        stage: undefined,
+                        api: existing
+                    };
                 }
 
-                return deleteAPIStage(existing.id, stage).then(function() {
-                    return existing;
+                return deleteAPIStage(existing.id, stageName, deploymentId).then(function(stage) {
+                    return {
+                        stage: stage,
+                        api: existing
+                    };
                 });
             });
         }
 
         // Fetch all stages and if there are none, delete the API entirely
-        promise = promise.then(function(existing) {
-            if (!existing.id) {
+        promise = promise.then(function(results) {
+            const api = results.api;
+            const stage = results.stage;
+
+            if (!api.id) {
                 // Nothing to delete
-                return existing;
+                return stage;
             }
 
-            return fetchAPIStages(existing.id).then(function(stages) {
+            return fetchAPIStages(api.id).then(function(stages) {
                 if (stages && stages.length === 0) {
-                    return deleteAPI(existing.id).then(function() {
-                        return existing;
+                    return deleteAPI(api.id).then(function() {
+                        return stage;
                     });
                 }
 
-                return existing;
+                return stage;
             });
         });
     } else if (command === 'Update' || command === 'Create') {
@@ -397,10 +426,10 @@ exports.handler = function(event, context) {
     }
 
     // Trigger the promise, handle completion/errors
-    promise.then(function(existing) {
-        console.log('Done', existing);
-        if (existing) {
-            return response.send(event, context, response.SUCCESS, existing, existing.isd ? existing.id : event.PhysicalResourceId);
+    promise.then(function(stage) {
+        console.log('Done', stage);
+        if (stage) {
+            return response.send(event, context, response.SUCCESS, stage, stage.deploymentId ? stage.deploymentId : event.PhysicalResourceId);
         } else {
             return response.send(event, context, response.SUCCESS, {}, event.PhysicalResourceId);
         }

--- a/lib/api-gateway-resource/index.js
+++ b/lib/api-gateway-resource/index.js
@@ -138,7 +138,7 @@ function deleteAPIStage(apiId, stageName, deploymentId) {
         // correct deploymentId)
         APIG.getStage({
             restApiId: apiId,
-            stageName:
+            stageName: stageName
         }, function(err, data) {
             if (err) return reject(err);
             resolve(data);

--- a/lib/api-gateway-resource/index.js
+++ b/lib/api-gateway-resource/index.js
@@ -145,8 +145,8 @@ function deleteAPIStage(apiId, stageName, deploymentId) {
         });
     }).then(function(stage) {
         if (stage.deploymentId !== deploymentId) {
-            // We are not going to delete as the stage we are looking for no-longer
-            // exists like we expect it to
+            // We are not going to delete the stage as our assumption
+            // about us being the ones that deployed it is not true
             return {
                 deploymentId: deploymentId,
                 stageName: stageName

--- a/lib/deploy/derive-stack-step.js
+++ b/lib/deploy/derive-stack-step.js
@@ -123,7 +123,7 @@ function loadAPI(result) {
         variables: variables
     });
 
-    stack['Resources']['LambdaToolsAPIGateway'] = JSON.parse(parsedTemplate);
+    stack['Resources']['LambdaToolsAPIGateway' + config.tools.majorVersion] = JSON.parse(parsedTemplate);
 
     return {
         context: context,

--- a/lib/deploy/derive-stack-step.js
+++ b/lib/deploy/derive-stack-step.js
@@ -7,6 +7,8 @@ const path = require('path');
 const Promise = require('bluebird');
 const _ = require('lodash');
 
+const config = require('../helpers/config');
+
 function loadTemplate(context) {
     return new Promise(function(resolve) {
         // Result
@@ -110,7 +112,7 @@ function loadAPI(result) {
     // Populate a template that will make our custom API Gateway resource
     const parsedTemplate = template({
         lambda: {
-            name: 'lambda-tools-api-gateway-resource'
+            name: config.tools.resources.apiGateway
         },
         dependencies: dependencies,
         stageName: _.snakeCase(context.project.stage),

--- a/lib/deploy/derive-stack-step.js
+++ b/lib/deploy/derive-stack-step.js
@@ -123,7 +123,7 @@ function loadAPI(result) {
         variables: variables
     });
 
-    stack['Resources']['LambdaToolsAPIGateway' + config.tools.majorVersion] = JSON.parse(parsedTemplate);
+    stack['Resources']['LambdaToolsAPIGateway'] = JSON.parse(parsedTemplate);
 
     return {
         context: context,

--- a/lib/helpers/config.js
+++ b/lib/helpers/config.js
@@ -5,6 +5,12 @@ const path = require('path');
 const root = require('find-root');
 const _ = require('lodash');
 
+// Information about LT itself
+const pkg = require('../../package.json');
+
+const majorVersion = pkg.version ? pkg.version.split('.')[0] : 'unknown';
+const resourcePrefix = _.compact([pkg.name, majorVersion]).join('-');
+
 /**
  *  Helper for loading config file of a project
  */
@@ -19,6 +25,15 @@ let result = {
     aws: {
         region: 'us-east-1',
         stage: 'dev'
+    },
+    tools: {
+        name: pkg.name,
+        version: pkg.version,
+        majorVersion: majorVersion,
+        resources: {
+            iamRole: [resourcePrefix, 'resource'].join('-'),
+            apiGateway: [resourcePrefix, 'api-gateway'].join('-'),
+        }
     }
 };
 

--- a/lib/helpers/config.js
+++ b/lib/helpers/config.js
@@ -7,9 +7,7 @@ const _ = require('lodash');
 
 // Information about LT itself
 const pkg = require('../../package.json');
-
 const majorVersion = pkg.version ? pkg.version.split('.')[0] : 'unknown';
-const resourcePrefix = _.compact([pkg.name, majorVersion]).join('-');
 
 /**
  *  Helper for loading config file of a project
@@ -31,8 +29,8 @@ let result = {
         version: pkg.version,
         majorVersion: majorVersion,
         resources: {
-            iamRole: [resourcePrefix, 'resource'].join('-'),
-            apiGateway: [resourcePrefix, 'api-gateway'].join('-')
+            iamRole: 'lambda-tools-helper',
+            apiGateway: 'lambda-tools-api-gateway-resource'
         }
     }
 };

--- a/lib/helpers/config.js
+++ b/lib/helpers/config.js
@@ -32,7 +32,7 @@ let result = {
         majorVersion: majorVersion,
         resources: {
             iamRole: [resourcePrefix, 'resource'].join('-'),
-            apiGateway: [resourcePrefix, 'api-gateway'].join('-'),
+            apiGateway: [resourcePrefix, 'api-gateway'].join('-')
         }
     }
 };

--- a/lib/setup/create-api-gateway-lambda.js
+++ b/lib/setup/create-api-gateway-lambda.js
@@ -11,10 +11,9 @@ const Promise = require('bluebird');
 const path = require('path');
 const fs = require('graceful-fs');
 const _ = require('lodash');
-const logger = require('../helpers/logger').shared;
 
-const FUNCTION_NAME = 'lambda-tools-api-gateway-resource';
-const ROLE_NAME = 'lambda-tools-helper';
+const logger = require('../helpers/logger').shared;
+const config = require('../helpers/config');
 
 function ensureLambdaRole(roleName, policyName) {
     const IAM = new AWS.IAM();
@@ -190,9 +189,9 @@ module.exports = function(region) {
         }
 
         // Create a basic role for the Lambda to use
-        const name = `Creating lambda execution role ${chalk.underline(ROLE_NAME)}`;
+        const name = `Creating lambda execution role ${chalk.underline(config.tools.resources.iamRole)}`;
         return logger.task(name, function(resolve, reject) {
-            ensureLambdaRole(ROLE_NAME, 'inline-policy').then(function(role) {
+            ensureLambdaRole(config.tools.resources.iamRole, 'inline-policy').then(function(role) {
                 resolve({
                     role: role,
                     zipFile: zipFile
@@ -202,9 +201,9 @@ module.exports = function(region) {
     })
     .then(function(results) {
         // Create or update the Lambda function
-        const name = `Creating lambda function ${chalk.underline(FUNCTION_NAME)}`;
+        const name = `Creating lambda function ${chalk.underline(config.tools.resources.apiGateway)}`;
         return logger.task(name, function(resolve, reject) {
-            updateOrCreateFunction(FUNCTION_NAME, results.zipFile, results.role).then(resolve, reject);
+            updateOrCreateFunction(config.tools.resources.apiGateway, results.zipFile, results.role).then(resolve, reject);
         });
     })
     .then(function(lambda) {


### PR DESCRIPTION
- [x] Issue exists - Related to 3.0 prep
- [x] Linter passes (`npm run lint`)
- [x] Tests pass (`npm run test`)
- [x] CircleCI build is green
- [x] Documentation is up to date (README + comments)

Brief overview of changes:
- Changed the custom API Gateway resource Lambda function that is created as part of `lambda setup`
- This should prepare for the oncoming non-backwards compatible change in 3.0 API Gateway resource.