### PR TITLE
Resource based permissions

### DIFF
--- a/lib/cf-resources/api-gateway-resource/index.js
+++ b/lib/cf-resources/api-gateway-resource/index.js
@@ -30,7 +30,7 @@ function replaceVariables(localPath, variables) {
             const value = variables[key];
 
             const re = new RegExp(`"\\$${key}"`, 'g');
-            body = body.replace(re, `"${value}"`);
+            body = body.replace(re, value ? `"${value}"` : `null`);
         });
 
         console.log('Variables replaced', body);

--- a/lib/cf-resources/api-gateway-resource/index.js
+++ b/lib/cf-resources/api-gateway-resource/index.js
@@ -28,9 +28,16 @@ function replaceVariables(localPath, variables) {
         const keys = Object.keys(variables);
         keys.forEach(function(key) {
             const value = variables[key];
-
             const re = new RegExp(`"\\$${key}"`, 'g');
-            body = body.replace(re, value ? `"${value}"` : `null`);
+
+            // Parse the value (to see if it is falsey)
+            try {
+                const parsed = JSON.parse(value);
+                body = body.replace(re, parsed ? `"${parsed}"` : `null`);
+            } catch (err) {
+                // Not valid JSON, treat it as a string
+                body = body.replace(re, `"${value}"`);
+            }
         });
 
         console.log('Variables replaced', body);

--- a/lib/deploy/derive-stack-step.js
+++ b/lib/deploy/derive-stack-step.js
@@ -127,10 +127,8 @@ function loadAPI(result) {
 
     variables.push({
         key: 'IamRoleArnApiGateway',
-        value: 'IamRoleApiGateway'
+        value: null
     });
-
-    dependencies.push('IamRoleApiGateway');
 
     // Populate a template that will make our custom API Gateway resource
     const parsedTemplate = template({

--- a/lib/deploy/derive-stack-step.js
+++ b/lib/deploy/derive-stack-step.js
@@ -127,7 +127,7 @@ function loadAPI(result) {
 
     variables.push({
         key: 'IamRoleArnApiGateway',
-        value: null
+        value: 'null'
     });
 
     // Populate a template that will make our custom API Gateway resource

--- a/lib/deploy/derive-stack-step.js
+++ b/lib/deploy/derive-stack-step.js
@@ -52,6 +52,7 @@ function loadLambdas(result) {
     // Templates
     const lambdaOutputTemplate = dot.template(fs.readFileSync(path.join(context.directories.root, 'templates/lambda.resource.dot'), 'utf8'));
     const lambdaVersionTemplate = dot.template(fs.readFileSync(path.join(context.directories.root, 'templates/lambda.version.dot'), 'utf8'));
+    const lambdaPermissionTemplate = dot.template(fs.readFileSync(path.join(context.directories.root, 'templates/lambda.permission.dot'), 'utf8'));
 
     // Version description is the timestamp of the current deployment
     const timestamp = context.project.timestamp;
@@ -70,6 +71,12 @@ function loadLambdas(result) {
             resource: config.tools.resources.lambdaVersion,
             lambda: camelName,
             description: timestamp
+        }));
+
+        // Permission
+        const permissionName = camelName + 'APIGPermission';
+        stack['Resources'][permissionName] = JSON.parse(lambdaPermissionTemplate({
+            lambda: versionName
         }));
 
         // Final output (used by API Gateway)

--- a/lib/deploy/templates/api.cf.dot
+++ b/lib/deploy/templates/api.cf.dot
@@ -28,7 +28,7 @@
         "StageName": "{{=it.stageName}}",
         "Variables": {
             {{~it.variables :value:idx}}
-            "{{=value.key}}": {
+            "{{=value.key}}": {{? value.value }}{
                 "Fn::Join": [
                     "/",
                     [
@@ -59,7 +59,7 @@
                         {{?}}
                     ]
                 ]
-            }{{? idx < it.variables.length - 1}},{{?}}
+            }{{??}}null{{?}}{{? idx < it.variables.length - 1}},{{?}}
             {{~}}
         }
     }

--- a/lib/deploy/templates/api.cf.dot
+++ b/lib/deploy/templates/api.cf.dot
@@ -28,7 +28,7 @@
         "StageName": "{{=it.stageName}}",
         "Variables": {
             {{~it.variables :value:idx}}
-            "{{=value.key}}": {{? value.value }}{
+            "{{=value.key}}": {{? value.value !== "null" }}{
                 "Fn::Join": [
                     "/",
                     [
@@ -59,7 +59,7 @@
                         {{?}}
                     ]
                 ]
-            }{{??}}null{{?}}{{? idx < it.variables.length - 1}},{{?}}
+            }{{??}}"{{=value.value}}"{{?}}{{? idx < it.variables.length - 1}},{{?}}
             {{~}}
         }
     }

--- a/lib/deploy/templates/cf.json
+++ b/lib/deploy/templates/cf.json
@@ -115,104 +115,6 @@
                     }
                 ]
             }
-        },
-        "IamRoleApiGateway": {
-            "Type": "AWS::IAM::Role",
-            "Properties": {
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17",
-                    "Statement": [
-                        {
-                            "Effect": "Allow",
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            },
-                            "Action": [
-                                "sts:AssumeRole"
-                            ]
-                        }
-                    ]
-                },
-                "Path": "/"
-            }
-        },
-        "IamInstanceProfileApiGateway": {
-            "Type": "AWS::IAM::InstanceProfile",
-            "DependsOn": [
-                "IamRoleApiGateway"
-            ],
-            "Properties": {
-                "Path": "/",
-                "Roles": [
-                    {
-                        "Ref": "IamRoleApiGateway"
-                    }
-                ]
-            }
-        },
-        "IamGroupApiGateway": {
-            "Type": "AWS::IAM::Group",
-            "Properties": {
-                "Path": "/"
-            }
-        },
-        "IamPolicyApiGateway": {
-            "Type": "AWS::IAM::Policy",
-            "DependsOn": [
-                "IamRoleApiGateway",
-                "IamGroupApiGateway"
-            ],
-            "Properties": {
-                "PolicyName": {
-                    "Fn::Join": [
-                        "_-_",
-                        [
-                            {
-                                "Ref": "aaStage"
-                            },
-                            {
-                                "Ref": "aaProjectName"
-                            },
-                            "api-gateway"
-                        ]
-                    ]
-                },
-                "PolicyDocument": {
-                    "Version": "2012-10-17",
-                    "Statement": [
-                        {
-                            "Effect": "Allow",
-                            "Action": [
-                                "lambda:InvokeFunction"
-                            ],
-                            "Resource": {
-                                "Fn::Join": [
-                                    ":",
-                                    [
-                                        "arn:aws:lambda",
-                                        {
-                                            "Ref": "AWS::Region"
-                                        },
-                                        "*:*"
-                                    ]
-                                ]
-                            }
-                        }
-                    ]
-                },
-                "Roles": [
-                    {
-                        "Ref": "IamRoleApiGateway"
-                    }
-                ],
-                "Groups": [
-                    {
-                        "Ref": "IamGroupApiGateway"
-                    }
-                ]
-            }
         }
     },
     "Outputs": {
@@ -221,15 +123,6 @@
             "Value": {
                 "Fn::GetAtt": [
                     "IamRoleLambda",
-                    "Arn"
-                ]
-            }
-        },
-        "IamRoleArnApiGateway": {
-            "Description": "ARN of the api gateway IAM role",
-            "Value": {
-                "Fn::GetAtt": [
-                    "IamRoleApiGateway",
                     "Arn"
                 ]
             }

--- a/lib/deploy/templates/lambda.permission.dot
+++ b/lib/deploy/templates/lambda.permission.dot
@@ -1,0 +1,16 @@
+{
+    "Type": "AWS::Lambda::Permission",
+    "DependsOn": [
+        "{{=it.lambda}}"
+    ],
+    "Properties": {
+        "FunctionName" : {
+            "Fn::GetAtt" : [
+                "{{=it.lambda}}",
+                "Arn"
+            ]
+        },
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com"
+    }
+}


### PR DESCRIPTION
- [x] Issue exists - N/A
- [x] Linter passes (`npm run lint`)
- [x] Tests pass (`npm run test`)
- [x] CircleCI build is green
- [x] Documentation is up to date (README + comments)

Brief overview of changes:
Turns out giving a role for API Gateway to assume is slower, often by quite a bit (when testing from the web console, often around 3x as slow). In order to mitigate the problem, all the Lambda functions should get a resource based permission that allows API Gateway to invoke them.
In order to make this change work with the old style API definitions, we also need to make sure the old role variable is substituted with a `null` in the final API Swagger file.