### PR TITLE
Use single bucket for entire toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,10 @@ The actions the user executing the scripts should be able to perform are:
     7. `lambda:GetAlias`
     8. `lambda:UpdateAlias`
     9. `lambda:CreateAlias`
+    10. `s3:ListBucket`
+    11. `s3:CreateBucket`
 2. `deploy`
-    1. `s3:CreateBucket`
-    2. `s3:PutObject`
+    1. `s3:PutObject` - Can be limited to specific bucket (`lambda-tools-<major-version>-assets-<region>`)
     3. `cloudformation:DescribeStacks`
     4. `cloudformation:UpdateStack`
     5. `cloudformation:CreateStack`
@@ -96,7 +97,7 @@ The actions the user executing the scripts should be able to perform are:
 
 ### Setup
 
-This step should only ever be run once for AWS account and region combination. The step will create the necessary Lambda function that acts as the CloudFormation resource for all stacks created by lambda-tools. If no region is defined, `us-east-1` is assumed. **If this step is not done, services with an `api.json` file will fail to deploy.**
+This step should only ever be run once for AWS account, region and LT version combination. The step will create the necessary Lambda functions that act as the CloudFormation resources for all stacks created by lambda-tools. If no region is defined, `us-east-1` is assumed. This also creates the staging S3 bucket that is used to store all stack assets. **If this step is not done, all deployments will fail**.
 
 ```
 lambda setup [options]

--- a/lib/deploy/derive-stack-step.js
+++ b/lib/deploy/derive-stack-step.js
@@ -138,8 +138,8 @@ function loadAPI(result) {
         dependencies: dependencies,
         stageName: _.snakeCase(context.project.stage),
         s3: {
-            bucket: context.project.bucket,
-            key: context.project.timestamp + '/' + path.basename(context.api.configuration)
+            bucket: [config.tools.resources.s3Bucket, context.project.region].join('-'),
+            key: [context.project.name, context.project.stage, context.project.timestamp, path.basename(context.api.configuration)].join('/')
         },
         variables: variables
     });

--- a/lib/deploy/setup-step.js
+++ b/lib/deploy/setup-step.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const AWS = require('aws-sdk');
 const path = require('path');
 const _ = require('lodash');
 const os = require('os');

--- a/lib/deploy/setup-step.js
+++ b/lib/deploy/setup-step.js
@@ -24,26 +24,6 @@ function prepareStagingDirectory(context) {
     });
 }
 
-function createS3Bucket(context) {
-    const bucket = `lambdas-${context.project.name}-${context.project.stage}`;
-
-    return context.logger.task(`Creating S3 bucket '${bucket}'`, function(resolve, reject) {
-        const S3 = new AWS.S3({apiVersion: '2006-03-01'});
-        S3.createBucket({
-            Bucket: bucket
-        }, function(err) {
-            if (err) {
-                return reject(err);
-            }
-
-            const ctx = _.clone(context);
-            ctx.project.bucket = bucket;
-
-            resolve(ctx);
-        });
-    });
-}
-
 function listLambdas(context) {
     return context.logger.task('Listing lambdas', function() {
         // Check if Lambdas directory exists
@@ -84,8 +64,8 @@ function listLambdas(context) {
 
             // Determine the locations in S3 we will upload the files to
             config['Properties']['Code'] = {
-                'S3Bucket': context.project.bucket,
-                'S3Key': context.project.timestamp + '/' + name + '.zip'
+                S3Bucket: [configuration.tools.resources.s3Bucket, context.project.region].join('-'),
+                S3Key: [context.project.name, context.project.stage, context.project.timestamp, name + '.zip'].join('/')
             };
 
             return {
@@ -110,7 +90,6 @@ function listLambdas(context) {
 module.exports = function(context) {
     return context.logger.task('Preparing stage', function(resolve, reject) {
         prepareStagingDirectory(context)
-        .then(createS3Bucket)
         .then(listLambdas)
         .then(resolve, reject);
     });

--- a/lib/deploy/update-stack-step.js
+++ b/lib/deploy/update-stack-step.js
@@ -6,10 +6,12 @@ const path = require('path');
 const Promise = require('bluebird');
 const _ = require('lodash');
 
+const config = require('../helpers/config');
+
 function uploadAssets(context) {
     const S3 = new AWS.S3({
         params: {
-            Bucket: context.project.bucket
+            Bucket: [config.tools.resources.s3Bucket, context.project.region].join('-')
         }
     });
 
@@ -21,7 +23,7 @@ function uploadAssets(context) {
                 }
 
                 S3.upload({
-                    Key: [context.project.timestamp, path.basename(lambda.zip)].join('/'),
+                    Key: [context.project.name, context.project.stage, context.project.timestamp, path.basename(lambda.zip)].join('/'),
                     Body: fs.createReadStream(lambda.zip)
                 }, function(err, result) {
                     if (err) {
@@ -46,7 +48,7 @@ function uploadAssets(context) {
             // Upload the configuration from the context
             return ctx.logger.task('Uploading stack configuration', function(res, rej) {
                 S3.upload({
-                    Key: [ctx.project.timestamp, path.basename(ctx.stack.configuration)].join('/'),
+                    Key: [ctx.project.name, ctx.project.stage, ctx.project.timestamp, path.basename(ctx.stack.configuration)].join('/'),
                     Body: fs.createReadStream(ctx.stack.configuration)
                 }, function(err, data) {
                     if (err) {
@@ -65,7 +67,7 @@ function uploadAssets(context) {
             if (!ctx.api.skip && ctx.api.configuration) {
                 return ctx.logger.task('Uploading API definition', function(res, rej) {
                     S3.upload({
-                        Key: [ctx.project.timestamp, path.basename(ctx.api.configuration)].join('/'),
+                        Key: [ctx.project.name, ctx.project.stage, ctx.project.timestamp, path.basename(ctx.api.configuration)].join('/'),
                         Body: fs.createReadStream(ctx.api.configuration)
                     }, function(err, data) {
                         if (err) {

--- a/lib/helpers/config.js
+++ b/lib/helpers/config.js
@@ -30,6 +30,7 @@ let result = {
         version: pkg.version,
         majorVersion: majorVersion,
         resources: {
+            s3Bucket: [resourcePrefix, 'assets'].join('-'),
             iamRole: [resourcePrefix, 'resource'].join('-'),
             apiGateway: [resourcePrefix, 'api-gateway'].join('-'),
             lambdaVersion: [resourcePrefix, 'lambda-version'].join('-')

--- a/lib/setup/create-cf-resources.js
+++ b/lib/setup/create-cf-resources.js
@@ -130,6 +130,34 @@ function updateOrCreateFunction(name, code, role) {
     });
 }
 
+function ensureS3Bucket(bucketName) {
+    const s3 = new AWS.S3();
+
+    return new Promise(function(resolve, reject) {
+        s3.headBucket({
+            Bucket: bucketName
+        }, function(err) {
+            if (err) {
+                // Create the bucket
+                resolve(false);
+            }
+
+            resolve(true);
+        });
+    }).then(function(exists) {
+        if (!exists) {
+            return new Promise(function(resolve, reject) {
+                s3.createBucket({
+                    Bucket: bucketName
+                }, function(err, data) {
+                    if (err) return reject(err);
+                    resolve(data);
+                });
+            });
+        }
+    });
+}
+
 module.exports = function(region) {
     // Configure AWS
     if (!region && !AWS.config.region) {
@@ -195,6 +223,13 @@ module.exports = function(region) {
                     return updateOrCreateFunction(lambda.name, zip, role);
                 }));
             }).then(resolve, reject);
+        });
+    })
+    .then(function() {
+        const bucketName = [config.tools.resources.s3Bucket, region].join('-');
+        const task = `Creating S3 bucket: ${chalk.underline(bucketName)}`;
+        return logger.task(task, function(resolve, reject) {
+            return ensureS3Bucket(bucketName).then(resolve, reject);
         });
     });
 };

--- a/lib/setup/create-cf-resources.js
+++ b/lib/setup/create-cf-resources.js
@@ -137,7 +137,7 @@ function updateOrCreateFunction(name, code, role) {
 function ensureS3Bucket(bucketName) {
     const s3 = new AWS.S3();
 
-    return new Promise(function(resolve, reject) {
+    return new Promise(function(resolve) {
         s3.headBucket({
             Bucket: bucketName
         }, function(err) {

--- a/lib/setup/create-cf-resources.js
+++ b/lib/setup/create-cf-resources.js
@@ -9,6 +9,7 @@ const AWS = require('aws-sdk');
 const chalk = require('chalk');
 const Promise = require('bluebird');
 const path = require('path');
+const dot = require('dot');
 const fs = Promise.promisifyAll(require('graceful-fs'));
 const fsx = require('../helpers/fs-additions');
 const os = require('os');
@@ -17,7 +18,7 @@ const config = require('../helpers/config');
 const logger = require('../helpers/logger').shared;
 const bundler = require('../deploy/bundle-lambdas-step');
 
-function ensureLambdaRole(roleName, policyName) {
+function ensureLambdaRole(roleName, policyName, region) {
     const iam = new AWS.IAM();
 
     return new Promise(function(resolve, reject) {
@@ -55,11 +56,14 @@ function ensureLambdaRole(roleName, policyName) {
         // Make sure the role has an appropriate inline policy
         return new Promise(function(resolve, reject) {
             const templatePath = path.resolve(__dirname, './templates/iam_policy.json');
+            const template = dot.template(fs.readFileSync(templatePath, 'utf8'));
 
             iam.putRolePolicy({
                 RoleName: role.RoleName,
                 PolicyName: policyName,
-                PolicyDocument: fs.readFileSync(templatePath, 'utf8')
+                PolicyDocument: template({
+                    s3Bucket: [config.tools.resources.s3Bucket, region].join('-')
+                })
             }, function(err) {
                 if (err) return reject(err);
                 resolve(role);
@@ -175,7 +179,7 @@ module.exports = function(region) {
     // Create a basic role for the Lambda to use
     const name = `Creating lambda execution role ${chalk.underline(config.tools.resources.iamRole)}`;
     return logger.task(name, function(resolve, reject) {
-        ensureLambdaRole(config.tools.resources.iamRole, 'inline-policy').then(function(role) {
+        ensureLambdaRole(config.tools.resources.iamRole, 'inline-policy', region).then(function(role) {
             resolve(role);
         }, reject);
     })

--- a/lib/setup/templates/iam_policy.json
+++ b/lib/setup/templates/iam_policy.json
@@ -32,7 +32,10 @@
                 "s3:GetObject",
                 "s3:HeadObject"
             ],
-            "Resource": "*"
+            "Resource": [
+                "arn:aws:s3:::{{=it.s3Bucket}}",
+                "arn:aws:s3:::{{=it.s3Bucket}}/*"
+            ]
         },
         {
             "Effect": "Allow",


### PR DESCRIPTION
- [x] Issue exists - #40 
- [x] Linter passes (`npm run lint`)
- [x] Tests pass (`npm run test`)
- [x] CircleCI build is green
- [x] Documentation is up to date (README + comments)

Brief overview of changes:
- Drop creating a S3 bucket per project per stage
- Add S3 bucket creation to `lambda setup`
- Change S3 keys that are generated during deployment to have a better structure (`<project>/<stage>/<timestamp>/<key>`), this should allow nicer browsing of all assets used by LT managed services