### PR TITLE
Fix a problem with Lambdas returning strings, not objects

### DIFF
--- a/lib/helpers/api-gateway-mapping-parser.js
+++ b/lib/helpers/api-gateway-mapping-parser.js
@@ -53,13 +53,35 @@ module.exports = function(template, params, context, payload, stageVariables) {
 
         input: {
             json: function(path) {
-                const matches = jsonpath.query(payload, path);
-                return JSON.stringify(matches.length > 0 ? matches[0] : null);
+                if (_.isObject(payload)) {
+                    const matches = jsonpath.query(payload, path);
+                    return JSON.stringify(matches.length > 0 ? matches[0] : null);
+                }
+
+                if (path === '$') {
+                    // All other types can only really handle requests to root
+                    return JSON.stringify(payload);
+                }
+
+                // Nothing for us to do
+                return undefined;
             },
 
             path: function(path) {
-                return jsonpath.query(payload, path);
+                if (_.isObject(payload)) {
+                    return jsonpath.query(payload, path);
+                }
+
+                if (path === '$') {
+                    // Other types can only really deal with root requests
+                    return payload;
+                }
+
+                // In other cases, there is nothing for us to return
+                return undefined;
             },
+
+            body: _.isString(payload) ? payload : JSON.stringify(payload),
 
             params: function(key) {
                 if (!key) {
@@ -84,5 +106,6 @@ module.exports = function(template, params, context, payload, stageVariables) {
     };
 
     // Always keep macros empty, API gateway doesn't support those
-    return velocity.render(template, data, {});
+    const result = velocity.render(template, data, {});
+    return _.unescape(result);
 };

--- a/lib/run/execution-wrapper.js
+++ b/lib/run/execution-wrapper.js
@@ -1,6 +1,8 @@
 // Wrapper for a Lambda function executing in a different process
 "use strict";
 
+const _ = require('lodash');
+
 function sendError(pid, err, callback) {
     const message = err.message || err;
     console.error(message);
@@ -13,7 +15,7 @@ function sendError(pid, err, callback) {
 }
 
 function sendResult(pid, result, callback) {
-    process.send({ result: JSON.stringify(result), type: 'result' }, null, callback);
+    process.send({ result: _.isString(result) ? result : JSON.stringify(result), type: 'result' }, null, callback);
 }
 
 function exit(error, result) {


### PR DESCRIPTION
- [x] Issue exists - Internal
- [x] Linter passes (`npm run lint`)
- [x] Tests pass (`npm run test`)
- [x] CircleCI build is green
- [x] Documentation is up to date (README + comments)

Brief overview of changes:
- When a Lambda function returns a string, not an object, then the execution wrapper should not stringify it
- In the API Gateway Mapping logic, we should avoid calling JSONPath functions on non-objects, and instead handle them best we can (root path can be resolved).
- This should help with mapping templates that aimed to produce a raw string, like those that want to have a different content-type.