### PR TITLE
Improve the context object that gets passed to the Lambda execution w…

### DIFF
--- a/bin/lambda-execute.js
+++ b/bin/lambda-execute.js
@@ -125,7 +125,7 @@ if (fsx.fileExists(eventPath)) {
 }
 
 const context = {
-    functionName: path.basename(program.file),
+    functionName: path.basename(path.dirname(program.file)),
     invokedFunctionArn: '$LATEST',
     memoryLimitInMB: '1024',
     timeout: program.timeout

--- a/bin/lambda-execute.js
+++ b/bin/lambda-execute.js
@@ -124,10 +124,8 @@ if (fsx.fileExists(eventPath)) {
     }
 }
 
+// We know the requested timeout, send that along to execution
 const context = {
-    functionName: path.basename(path.dirname(program.file)),
-    invokedFunctionArn: '$LATEST',
-    memoryLimitInMB: '1024',
     timeout: program.timeout
 };
 

--- a/lib/run/execution-wrapper.js
+++ b/lib/run/execution-wrapper.js
@@ -41,6 +41,8 @@ function parseArgs(args) {
         } else if (id === 4) {
             ret.event = JSON.parse(val);
         } else if (id === 5) {
+            ret.context = JSON.parse(val);
+        } else if (id === 6) {
             ret.timeout = val;
         }
 
@@ -48,7 +50,7 @@ function parseArgs(args) {
     }, { });
 }
 
-function wrapper(path, handler, evt, timeout) {
+function wrapper(path, handler, evt, context, timeout) {
     timeout = parseInt(timeout || 6000, 10);
     handler = handler || 'handler';
     evt = evt || {};
@@ -58,7 +60,6 @@ function wrapper(path, handler, evt, timeout) {
     const now = new Date().getTime();
     const deadline = now + timeout;
 
-    let context = {};
     const watchdog = setTimeout(function() {
         context.fail(new Error('Operation timed out'));
     }, timeout);
@@ -71,7 +72,7 @@ function wrapper(path, handler, evt, timeout) {
     });
 
     // Create a context object to pass along to the Lambda function
-    context = {
+    context = _.assign(context, {
         done: function(error, result) {
             clearTimeout(watchdog);
             exit(error, result);
@@ -92,7 +93,7 @@ function wrapper(path, handler, evt, timeout) {
         },
 
         callbackWaitsForEmptyEventLoop: true
-    };
+    });
 
     try {
         const fn = require(path)[handler];
@@ -126,4 +127,4 @@ function wrapper(path, handler, evt, timeout) {
 }
 
 const args = parseArgs(process.argv);
-wrapper(args.path, args.handler, args.event, args.timeout);
+wrapper(args.path, args.handler, args.event, args.context, args.timeout);

--- a/lib/run/execution.js
+++ b/lib/run/execution.js
@@ -6,15 +6,31 @@ const Promise = require('bluebird');
 const cp = require('child_process');
 const moment = require('moment');
 const path = require('path');
+const uuid = require('node-uuid');
 
 module.exports = function *(lambdaPath, event, context, environment) {
     const pathComponents = lambdaPath.split('.');
+    const name = path.basename(path.dirname(lambdaPath));
     let handlerFunction = 'handler';
 
     if (pathComponents[pathComponents.length - 1] !== 'js') {
         handlerFunction = pathComponents[pathComponents.length - 1];
         pathComponents[pathComponents.length - 1] = 'js';
     }
+
+    // Reasonable default values for context
+    context = _.assign({
+        timeout: 6,
+        functionName: name,
+        functionVersion: '$LATEST',
+        invokedFunctionArn: `arn:lt:lambda:${name}/$LATEST`,
+        memoryLimitInMB: 256,
+        awsRequestId: uuid.v4(),
+        logGroupName: 'local',
+        logStreamName: '',
+        identity: null,
+        clientContext: null
+    }, context);
 
     return new Promise(function(resolve, reject) {
         const args = [pathComponents.join('.'), handlerFunction, JSON.stringify(event), JSON.stringify(context), context.timeout * 1000];

--- a/lib/run/execution.js
+++ b/lib/run/execution.js
@@ -17,7 +17,7 @@ module.exports = function *(lambdaPath, event, context, environment) {
     }
 
     return new Promise(function(resolve, reject) {
-        const args = [pathComponents.join('.'), handlerFunction, JSON.stringify(event), context.timeout * 1000];
+        const args = [pathComponents.join('.'), handlerFunction, JSON.stringify(event), JSON.stringify(context), context.timeout * 1000];
 
         const child = cp.fork(path.resolve(__dirname, './execution-wrapper'), args, {
             env: _.assign({ HOME: process.env.HOME, PATH: process.env.PATH, USER: process.env.USER }, environment),

--- a/lib/run/route.js
+++ b/lib/run/route.js
@@ -15,8 +15,9 @@ function lambdaRoute(apiDefinition, program) {
         // Derive the Lambda function file path (ignoring whether it exists or not)
         let lambdaPath = _.get(apiDefinition, 'uri');
 
-        // Start building the context
-        let context = { functionName: _.kebabCase(_.trim(lambdaPath, '$l')), invokedFunctionArn: '$LATEST', memoryLimitInMB: '1024', timeout: 6};
+        // We can feed in some context data to execution. This will
+        // be combined with some reasonable defaults
+        let context = {};
 
         if (_.startsWith(lambdaPath, '$l')) {
             lambdaPath = lambdaPath.slice(2);
@@ -44,12 +45,6 @@ function lambdaRoute(apiDefinition, program) {
         console.log(chalk.gray('\t--'), 'Creating integration');
         const integration = Integration(this, apiDefinition);
         console.log(`\t${JSON.stringify(integration, null, '\t').split('\n').join('\n\t')}\n`);
-
-        // Extend context to give it the necessary functions
-        // (done, fail, succeed, timeRemainingInMillis)
-        // and include values derived by our integration step
-        context = _.merge(context, integration.context);
-        context.awsRequestId = context.requestId;
 
         console.log(chalk.gray('\t--'), 'Executing Lambda function (' + path.relative(path.resolve(program.directory, 'lambdas'), lambdaPath) + ')');
         console.log(`\t${JSON.stringify(integration.event, null, '\t').split('\n').join('\n\t')}\n`);

--- a/lib/run/route.js
+++ b/lib/run/route.js
@@ -16,7 +16,7 @@ function lambdaRoute(apiDefinition, program) {
         let lambdaPath = _.get(apiDefinition, 'uri');
 
         // Start building the context
-        let context = { functionName: lambdaPath, invokedFunctionArn: '$LATEST', memoryLimitInMB: '1024', timeout: 6};
+        let context = { functionName: _.kebabCase(_.trim(lambdaPath, '$l')), invokedFunctionArn: '$LATEST', memoryLimitInMB: '1024', timeout: 6};
 
         if (_.startsWith(lambdaPath, '$l')) {
             lambdaPath = lambdaPath.slice(2);

--- a/lib/run/route.js
+++ b/lib/run/route.js
@@ -17,7 +17,7 @@ function lambdaRoute(apiDefinition, program) {
 
         // We can feed in some context data to execution. This will
         // be combined with some reasonable defaults
-        let context = {};
+        const context = {};
 
         if (_.startsWith(lambdaPath, '$l')) {
             lambdaPath = lambdaPath.slice(2);


### PR DESCRIPTION
**Will think about this a bit, there is likely a better way to guarantee context is _exactly_ what it needs to be in both `execute` as well as `run`.**

- [x] Issue exists - #47 
- [x] Linter passes (`npm run lint`)
- [x] Tests pass (`npm run test`)
- [x] CircleCI build is green
- [x] Documentation is up to date (README + comments)

Brief overview of changes:
- Allowed a context object to be passed to the execution wrapper
- Modified the context object that gets passed to the execution wrapper in `lambda execute` and `lambda run`
- The values that are currently embedded into the context object are not necessarily good