### PR TITLE
Support for source maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ _It is important to emphasize, the source location of the mapped asset can also 
 
 ### Source Maps
 
-During deployment source maps for the transpiled/bundled code are generated and uploaded along with all other assets to S3. These will have the same name as the ZIP of the bundled code, followed by a `.map` suffix. In addition, the local staging directory will also include a source map for the non-transpiled version of the code (along with the original non-transpiled bundle code).
+During deployment source maps for the transpiled/bundled code are generated and uploaded along with all other assets to S3. These will have the same name as the ZIP of the bundled code, but with a `.js.map` extension. In addition, the local staging directory will also include a source map for the non-transpiled version of the code (along with the original non-transpiled bundle code).
 
 ### Single Lambda
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,10 @@ console.log(fs.readFileSync('./response_template.txt', 'utf8')); // Prints out t
 
 _It is important to emphasize, the source location of the mapped asset can also point to another directory - this allows reusing assets between Lambda functions, while also allowing these assets to have different names in specific Lambda functions._
 
+### Source Maps
+
+During deployment source maps for the transpiled/bundled code are generated and uploaded along with all other assets to S3. These will have the same name as the ZIP of the bundled code, followed by a `.map` suffix. In addition, the local staging directory will also include a source map for the non-transpiled version of the code (along with the original non-transpiled bundle code).
+
 ### Single Lambda
 
 A single Lambda function can be deployed without using CloudFormation via `lambda deploy-single`. This simply updates the Lambda function code. **The script assumes that the Lambda function already exists and its configuration is suitable. This deployment script does not update the Lambda function configuration nor does it support static assets.**

--- a/lib/deploy/bundle-lambdas-step.js
+++ b/lib/deploy/bundle-lambdas-step.js
@@ -16,6 +16,7 @@ const es2015presets = require('babel-preset-es2015');
 const node4presets = require('babel-preset-es2015-node4');
 const Browserify = require('browserify');
 const envify = require('envify/custom');
+const exorcist = require('exorcist');
 
 /**
  *  Helper for recursively adding all dependencies to an archive
@@ -59,10 +60,12 @@ function archiveDependencies(cwd, pkg) {
  *                 with the entry point
  *  @param exclude Array of packages to exclude from the bundle, defaults to aws-sdk
  *  @param environment Env variables to envify
+ *  @param bundlePath Path to save the bundled code to
+ *  @param sourceMapPath Path to save the source maps to
  *
- *  @returns Promise that resolves to the bundled code
+ *  @returns Promise that bundles the code and writes it to a file
  */
-function bundleLambda(lambda, exclude, environment) {
+function bundleLambda(lambda, exclude, environment, bundlePath, sourceMapPath) {
     environment = environment || {};
     exclude = exclude || [];
 
@@ -75,6 +78,7 @@ function bundleLambda(lambda, exclude, environment) {
             commondir: false,
             ignoreMissing: true,
             detectGlobals: true,
+            debug: !!sourceMapPath,
             insertGlobalVars: {
                 process: function() {}
             }
@@ -96,9 +100,17 @@ function bundleLambda(lambda, exclude, environment) {
             });
         }
 
-        bundler.bundle(function(err, data) {
-            if (err) return reject(err);
-            resolve(data);
+        let stream = bundler.bundle();
+        if (sourceMapPath) {
+            stream = stream.pipe(exorcist(sourceMapPath));
+        }
+
+        stream.pipe(fs.createWriteStream(bundlePath));
+
+        stream.on('error', function(err) {
+            reject(err);
+        }).on('end', function() {
+            resolve();
         });
     });
 }
@@ -127,22 +139,21 @@ module.exports = function(context) {
             // Process all Lambda functions (serially, as Babel and Browserify don't
             // like parallelism for some reason)
             return Promise.mapSeries(context.lambdas, function(lambda) {
-                const bundledPath = path.resolve(context.directories.staging, lambda.name + '.bundled.js');
-                const transpiledPath = path.resolve(context.directories.staging, lambda.name + '.transpiled.js');
-                const zippedPath = path.resolve(context.directories.staging, lambda.name + '.zip');
-                const manifestPath = path.resolve(context.directories.staging, lambda.name + '.manifest.json');
+                const basePath = context.directories.staging;
+                const bundledPath = path.resolve(basePath, lambda.name + '.bundled.js');
+                const bundledMapPath = path.resolve(basePath, lambda.name + '.bundled.js.map');
+                const transpiledPath = path.resolve(basePath, lambda.name + '.transpiled.js');
+                const transpiledMapPath = path.resolve(basePath, lambda.name + '.transpiled.js.map');
+                const zippedPath = path.resolve(basePath, lambda.name + '.zip');
+                const manifestPath = path.resolve(basePath, lambda.name + '.manifest.json');
 
                 const runtime = _.get(lambda, 'config.Properties.Runtime', 'nodejs');
 
                 return context.logger.task(lambda.name, function(resolve, reject) {
                     // First, bundle the code (this bundle will be used for the manifest etc)
                     logger.task('Bundling', function(res, rej) {
-                        bundleLambda(lambda, excluded, env)
+                        bundleLambda(lambda, excluded, env, bundledPath, bundledMapPath)
                         .then(res, rej);
-                    })
-                    .then(function(bundledCode) {
-                        // Save the bundled code to file
-                        return fs.writeFileAsync(bundledPath, bundledCode);
                     })
                     .then(function() {
                         // Generate the manifest for this particular Lambda function (bundle)
@@ -243,7 +254,9 @@ module.exports = function(context) {
                             // Determine appropriate transpiler presets
                             const options = {
                                 compact: true,
-                                comments: false
+                                comments: false,
+                                sourceMaps: true,
+                                inputSourceMap: JSON.parse(fs.readFileSync(bundledMapPath))
                             };
 
                             if (runtime === 'nodejs') {
@@ -256,12 +269,14 @@ module.exports = function(context) {
 
                             babel.transformFile(bundledPath, options, function(err, transpiled) {
                                 if (err) return rej(err);
-                                res(transpiled.code);
+                                res(transpiled);
                             });
                         })
-                        .then(function(transpiledCode) {
+                        .then(function(transpiled) {
                             // Write the code to disk
-                            return fs.writeFileAsync(transpiledPath, transpiledCode);
+                            return fs.writeFileAsync(transpiledPath, transpiled.code).then(function() {
+                                return fs.writeFileAsync(transpiledMapPath, JSON.stringify(transpiled.map));
+                            });
                         })
                         .then(function() {
                             // Archive the resulting code
@@ -312,7 +327,8 @@ module.exports = function(context) {
                                 })
                                 .then(function() {
                                     return _.assign({}, lambda, {
-                                        zip: zippedPath
+                                        zip: zippedPath,
+                                        sourceMap: transpiledMapPath
                                     });
                                 }).then(res, rej);
                             });

--- a/lib/deploy/update-stack-step.js
+++ b/lib/deploy/update-stack-step.js
@@ -32,6 +32,23 @@ function uploadAssets(context) {
 
                     res(result);
                 });
+            }).then(function() {
+                return context.logger.task(`Uploading ${path.basename(lambda.sourceMap)}`, function(res, rej) {
+                    if (!lambda.sourceMap) {
+                        return rej(new Error('No source map to upload'));
+                    }
+
+                    S3.upload({
+                        Key: [context.project.name, context.project.stage, context.project.timestamp, path.basename(lambda.sourceMap)].join('/'),
+                        Body: fs.createReadStream(lambda.sourceMap)
+                    }, function(err, result) {
+                        if (err) {
+                            return rej(err);
+                        }
+
+                        res(result);
+                    });
+                });
             });
         })
         .then(function(results) {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "detective": "^4.3.1",
     "dot": "^1.0.3",
     "envify": "^3.4.0",
+    "exorcist": "^0.4.0",
     "find-root": "^1.0.0",
     "fs-extra": "^0.26.7",
     "graceful-fs": "^4.1.4",


### PR DESCRIPTION
- [x] Issue exists - #50 
- [x] Linter passes (`npm run lint`)
- [x] Tests pass (`npm run test`)
- [x] CircleCI build is green
- [x] Documentation is up to date (README + comments)

Brief overview of changes:
- Added support for source map generation during deployment
- Made sure generated source maps are stored in the staging directory as well as uploaded along with the bundled & transpiled code to the S3 staging bucket.