### PR TITLE
Make sure to check for result before checking its type

### DIFF
--- a/lib/run/execution.js
+++ b/lib/run/execution.js
@@ -106,7 +106,7 @@ module.exports = function *(lambdaPath, event, context, environment, assets) {
 
             child.on('exit', function() {
                 console.log('');
-                if (result.type === 'error') {
+                if (result && result.type === 'error') {
                     reject(new Error(result.result));
                 } else {
                     resolve(result.result);


### PR DESCRIPTION
- [x] Issue exists - #53 
- [x] Linter passes (`npm run lint`)
- [x] Tests pass (`npm run test`)
- [x] CircleCI build is green
- [x] Documentation is up to date (README + comments)

Brief overview of changes:
- Made sure that the result is checked for existence before checking if it is an error
- This will potentially cause an erroneous result to be reported as a success, however, the application should no longer crash.