### PR TITLE
Improve the way LT logs out execution times

### DIFF
--- a/lib/run/execution.js
+++ b/lib/run/execution.js
@@ -106,7 +106,12 @@ module.exports = function *(lambdaPath, event, context, environment, assets) {
 
             child.on('exit', function() {
                 console.log('');
-                if (result && result.type === 'error') {
+
+                if (!result) {
+                    return reject(new Error('Execution did not produce a result'));
+                }
+
+                if (result.type === 'error') {
                     reject(new Error(result.result));
                 } else {
                     resolve(result.result);

--- a/lib/run/execution.js
+++ b/lib/run/execution.js
@@ -94,14 +94,14 @@ module.exports = function *(lambdaPath, event, context, environment, assets) {
                 const dateString = moment().format('DD-MM-YYYY HH:mm:ss.SSS');
                 const logString = data.toString().split('\n').join('\n\t\t').trim();
 
-                console.log(`\t${chalk.gray('[' + dateString + ']')} ${logString}`);
+                console.log(`\t${chalk.gray('[' + dateString + ' ' + context.awsRequestId + ']')} ${logString}`);
             });
 
             child.stderr.on('data', function(data) {
                 const dateString = moment().format('DD-MM-YYYY HH:mm:ss.SSS');
                 const logString = data.toString().split('\n').join('\n\t\t').trim();
 
-                console.log(`\t${chalk.gray('[' + dateString + ']')} ERROR: ${chalk.red(logString)}`);
+                console.log(`\t${chalk.gray('[' + dateString + ' ' + context.awsRequestId + ']')} ERROR: ${chalk.red(logString)}`);
             });
 
             child.on('exit', function() {

--- a/lib/run/route.js
+++ b/lib/run/route.js
@@ -3,6 +3,7 @@
 const chalk = require('chalk');
 const path = require('path');
 const _ = require('lodash');
+const perfy = require('perfy');
 
 const Integration = require('./integration');
 const Execution = require('./execution');
@@ -56,12 +57,15 @@ function lambdaRoute(apiDefinition, program) {
             lambdaPath = path.resolve(lambdaPath, handler);
         }
 
-        console.log(chalk.gray('\t--'), 'Creating integration');
+        perfy.start('integration');
+        console.log(chalk.gray('\t<--'), 'Creating integration');
         const integration = Integration(this, apiDefinition);
-        console.log(`\t${JSON.stringify(integration, null, '\t').split('\n').join('\n\t')}\n`);
+        console.log(`\t${JSON.stringify(integration, null, '\t').split('\n').join('\n\t')}`);
+        console.log(chalk.gray('\t-->'), 'Creating integration', chalk.gray(`${_.round(perfy.end('integration').milliseconds, 0)}ms\n`));
 
-        console.log(chalk.gray('\t--'), 'Executing Lambda function (' + path.relative(path.resolve(program.directory, 'lambdas'), lambdaPath) + ')');
-        console.log(`\t${JSON.stringify(integration.event, null, '\t').split('\n').join('\n\t')}\n`);
+        perfy.start('execution');
+        console.log(chalk.gray('\t<--'), 'Executing Lambda function (' + path.relative(path.resolve(program.directory, 'lambdas'), lambdaPath) + ')');
+        console.log('\tWith event\n', `\t${JSON.stringify(integration.event, null, '\t').split('\n').join('\n\t')}\n`);
 
         let result;
         try {
@@ -70,9 +74,15 @@ function lambdaRoute(apiDefinition, program) {
             result = error.message;
         }
 
+        console.log(chalk.gray('\t-->'), 'Executing Lambda function', chalk.gray(`${_.round(perfy.end('execution').milliseconds, 0)}ms\n`))
+
         // Final step is to map the result back to a response
-        console.log(chalk.gray('\t--'), 'Creating response');
+        perfy.start('response');
+        console.log(chalk.gray('\t<--'), 'Creating response');
         const response = Responder(this, apiDefinition, result);
+        console.log(`\t${JSON.stringify(response, null, '\t').split('\n').join('\n\t')}`);
+        console.log(chalk.gray('\t-->'), 'Creating response', chalk.gray(`${_.round(perfy.end('response').milliseconds, 0)}ms\n`));
+
         this.response.status = response.status;
         this.response.type = response.type;
         this.response.body = response.body;

--- a/lib/run/route.js
+++ b/lib/run/route.js
@@ -4,12 +4,22 @@ const chalk = require('chalk');
 const path = require('path');
 const _ = require('lodash');
 const perfy = require('perfy');
+const UUID = require('node-uuid');
 
 const Integration = require('./integration');
 const Execution = require('./execution');
 const Responder = require('./responder');
 
 const fsx = require('../helpers/fs-additions');
+
+function startTime(key, name) {
+    perfy.start(key);
+    console.log(chalk.gray('\t<--'), name);
+}
+
+function endTime(key, name) {
+    console.log(chalk.gray('\t-->'), name, chalk.gray(`${_.round(perfy.end(key).milliseconds)}ms\n`));
+}
 
 function lambdaRoute(apiDefinition, program) {
     return function *() {
@@ -20,12 +30,14 @@ function lambdaRoute(apiDefinition, program) {
         // be combined with some reasonable defaults
         const context = {};
 
+        // For tracking purposes, create a request ID
+        const key = UUID.v4();
+
         // Any assets that will get exposed to the Lambda function
         let assets = {};
 
         if (_.startsWith(lambdaPath, '$l')) {
-            perfy.start('configuration');
-            console.log(chalk.gray('\t<--'), 'Configuring Lambda function');
+            startTime(key, 'Configuring Lambda function');
             lambdaPath = lambdaPath.slice(2);
             lambdaPath = _.kebabCase(lambdaPath.charAt(0).toLowerCase() + lambdaPath.substring(1));
             lambdaPath = path.resolve(program.directory, 'lambdas', lambdaPath);
@@ -57,17 +69,15 @@ function lambdaRoute(apiDefinition, program) {
             }
 
             lambdaPath = path.resolve(lambdaPath, handler);
-            console.log(chalk.gray('\t-->'), 'Configuring Lambda function', chalk.gray(`${_.round(perfy.end('configuration').milliseconds)}ms\n`));
+            endTime(key, 'Configuring Lambda function');
         }
 
-        perfy.start('integration');
-        console.log(chalk.gray('\t<--'), 'Creating integration');
+        startTime(key, 'Creating integration');
         const integration = Integration(this, apiDefinition);
         console.log(`\t${JSON.stringify(integration, null, '\t').split('\n').join('\n\t')}`);
-        console.log(chalk.gray('\t-->'), 'Creating integration', chalk.gray(`${_.round(perfy.end('integration').milliseconds, 0)}ms\n`));
+        endTime(key, 'Creating integration');
 
-        perfy.start('execution');
-        console.log(chalk.gray('\t<--'), 'Executing Lambda function (' + path.relative(path.resolve(program.directory, 'lambdas'), lambdaPath) + ')\n');
+        startTime(key, `Executing Lambda (${path.relative(path.resolve(program.directory, 'lambdas'), lambdaPath)})\n`);
 
         let result;
         try {
@@ -76,14 +86,13 @@ function lambdaRoute(apiDefinition, program) {
             result = error.message;
         }
 
-        console.log(chalk.gray('\t-->'), 'Executing Lambda function', chalk.gray(`${_.round(perfy.end('execution').milliseconds, 0)}ms\n`));
+        endTime(key, 'Executing Lambda function');
 
         // Final step is to map the result back to a response
-        perfy.start('response');
-        console.log(chalk.gray('\t<--'), 'Creating response');
+        startTime(key, 'Creating response');
         const response = Responder(this, apiDefinition, result);
         console.log(`\t${JSON.stringify(response, null, '\t').split('\n').join('\n\t')}`);
-        console.log(chalk.gray('\t-->'), 'Creating response', chalk.gray(`${_.round(perfy.end('response').milliseconds, 0)}ms\n`));
+        endTime(key, 'Creating response');
 
         this.response.status = response.status;
         this.response.type = response.type;

--- a/lib/run/route.js
+++ b/lib/run/route.js
@@ -24,6 +24,8 @@ function lambdaRoute(apiDefinition, program) {
         let assets = {};
 
         if (_.startsWith(lambdaPath, '$l')) {
+            perfy.start('configuration');
+            console.log(chalk.gray('\t<--'), 'Configuring Lambda function');
             lambdaPath = lambdaPath.slice(2);
             lambdaPath = _.kebabCase(lambdaPath.charAt(0).toLowerCase() + lambdaPath.substring(1));
             lambdaPath = path.resolve(program.directory, 'lambdas', lambdaPath);
@@ -55,6 +57,7 @@ function lambdaRoute(apiDefinition, program) {
             }
 
             lambdaPath = path.resolve(lambdaPath, handler);
+            console.log(chalk.gray('\t-->'), 'Configuring Lambda function', chalk.gray(`${_.round(perfy.end('configuration').milliseconds)}ms\n`));
         }
 
         perfy.start('integration');
@@ -64,8 +67,7 @@ function lambdaRoute(apiDefinition, program) {
         console.log(chalk.gray('\t-->'), 'Creating integration', chalk.gray(`${_.round(perfy.end('integration').milliseconds, 0)}ms\n`));
 
         perfy.start('execution');
-        console.log(chalk.gray('\t<--'), 'Executing Lambda function (' + path.relative(path.resolve(program.directory, 'lambdas'), lambdaPath) + ')');
-        console.log('\tWith event\n', `\t${JSON.stringify(integration.event, null, '\t').split('\n').join('\n\t')}\n`);
+        console.log(chalk.gray('\t<--'), 'Executing Lambda function (' + path.relative(path.resolve(program.directory, 'lambdas'), lambdaPath) + ')\n');
 
         let result;
         try {

--- a/lib/run/route.js
+++ b/lib/run/route.js
@@ -76,7 +76,7 @@ function lambdaRoute(apiDefinition, program) {
             result = error.message;
         }
 
-        console.log(chalk.gray('\t-->'), 'Executing Lambda function', chalk.gray(`${_.round(perfy.end('execution').milliseconds, 0)}ms\n`))
+        console.log(chalk.gray('\t-->'), 'Executing Lambda function', chalk.gray(`${_.round(perfy.end('execution').milliseconds, 0)}ms\n`));
 
         // Final step is to map the result back to a response
         perfy.start('response');

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "lodash": "^4.8.x",
     "moment": "^2.11.0",
     "node-uuid": "^1.4.7",
+    "perfy": "^1.1.2",
     "readline-sync": "^1.2.21",
     "resolve": "^1.1.7",
     "simple-archiver": "^0.1.3",


### PR DESCRIPTION
- [x] Issue exists - Internal
- [x] Linter passes (`npm run lint`)
- [x] Tests pass (`npm run test`)
- [x] CircleCI build is green
- [x] Documentation is up to date (README + comments)

Brief overview of changes:
- Improved logging in `lambda run`, making sure that individual steps are clearly timed and reported in the logs
- Also made sure that the request ID is logged out along with the message from the Lambda function, which helps when multiple requests are being handled at the same time.
