### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/run/execution.js
+++ b/lib/run/execution.js
@@ -6,7 +6,7 @@ const Promise = require('bluebird');
 const cp = require('child_process');
 const moment = require('moment');
 const path = require('path');
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 
 const fs = require('fs-extra');
 

--- a/lib/run/integration.js
+++ b/lib/run/integration.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const _ = require('lodash');
-const UUID = require('node-uuid');
+const UUID = require('uuid');
 const mappingTemplate = require('../helpers/api-gateway-mapping-parser');
 
 //

--- a/lib/run/route.js
+++ b/lib/run/route.js
@@ -4,7 +4,7 @@ const chalk = require('chalk');
 const path = require('path');
 const _ = require('lodash');
 const perfy = require('perfy');
-const UUID = require('node-uuid');
+const UUID = require('uuid');
 
 const Integration = require('./integration');
 const Execution = require('./execution');

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "koa-router": "^5.3.0",
     "lodash": "^4.8.x",
     "moment": "^2.11.0",
-    "node-uuid": "^1.4.7",
     "perfy": "^1.1.2",
     "readline-sync": "^1.2.21",
     "resolve": "^1.1.7",
@@ -59,6 +58,7 @@
     "swagger-parser": "^3.3.0",
     "untildify": "^2.1.0",
     "update-notifier": "^0.7.0",
+    "uuid": "^3.0.0",
     "velocityjs": "^0.7.5"
   },
   "devDependencies": {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.