### PR TITLE
Flexible resource names

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,12 +97,22 @@ The actions the user executing the scripts should be able to perform are:
 5. `describe`
     1. N/A
 
-### Setup
+## Setup
 
 This step should only ever be run once for AWS account, region and LT version combination. The step will create the necessary Lambda functions that act as the CloudFormation resources for all stacks created by lambda-tools. If no region is defined, `us-east-1` is assumed. This also creates the staging S3 bucket that is used to store all stack assets. **If this step is not done, all deployments will fail**.
 
+Since the deployed Lambda code is held in S3 buckets and S3 bucket names must be unique across all accounts, deploys will fail unless you provide an unique resource name prefix when running the `setup` command via the resource prefix option described below.
+
 ```
 lambda setup [options]
+```
+
+### Options
+```
+-h, --help                      output usage information
+-r, --region <string>           Region to setup in, if not set otherwise, defaults to 'us-east-1'
+-p, --resource-prefix <string>  Prefix to use with all lambda-tools created AWS resources, defaults to '' (empty string)
+--no-color                      Turn off ANSI coloring in output
 ```
 
 ## Describe

--- a/bin/lambda-setup.js
+++ b/bin/lambda-setup.js
@@ -13,12 +13,12 @@ const createResources = require('../lib/setup/create-cf-resources.js');
 
 program
     .option('-r, --region <string>', 'Region to setup in, if not set otherwise, defaults to \'us-east-1\'')
-    .option('-b, --bucket-prefix <string>', 'Prefix to use with the S3 bucket name used to store the deployment assets, defaults to empty string')
+    .option('-p, --resource-prefix <string>', 'Prefix to use with all lambda-tools created AWS resources, defaults to \'\' (empty string)')
     .option('--no-color', 'Turn off ANSI coloring in output')
     .parse(process.argv);
 
 chalk.enabled = program.color;
 
 logger.task(`Setting up ${chalk.underline('lambda-tools')}`, function(resolve, reject) {
-    createResources(program.region, program.bucketPrefix).then(resolve, reject);
+    createResources(program.region, program.resourcePrefix).then(resolve, reject);
 });

--- a/bin/lambda-setup.js
+++ b/bin/lambda-setup.js
@@ -13,11 +13,12 @@ const createResources = require('../lib/setup/create-cf-resources.js');
 
 program
     .option('-r, --region <string>', 'Region to setup in, if not set otherwise, defaults to \'us-east-1\'')
+    .option('-b, --bucket-prefix <string>', 'Prefix to use with the S3 bucket name used to store the deployment assets, defaults to empty string')
     .option('--no-color', 'Turn off ANSI coloring in output')
     .parse(process.argv);
 
 chalk.enabled = program.color;
 
 logger.task(`Setting up ${chalk.underline('lambda-tools')}`, function(resolve, reject) {
-    createResources(program.region).then(resolve, reject);
+    createResources(program.region, program.bucketPrefix).then(resolve, reject);
 });

--- a/lib/helpers/config.js
+++ b/lib/helpers/config.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const Configstore = require('configstore');
 const fsx = require('./fs-additions');
 const path = require('path');
 const root = require('find-root');
@@ -9,6 +10,8 @@ const _ = require('lodash');
 const pkg = require('../../package.json');
 const majorVersion = pkg.version ? pkg.version.split('.')[0] : 'unknown';
 const resourcePrefix = _.compact([pkg.name, majorVersion]).join('-');
+
+const bucketPrefix = (new Configstore(pkg.name)).get('S3BucketPrefix');
 
 /**
  *  Helper for loading config file of a project
@@ -30,7 +33,7 @@ let result = {
         version: pkg.version,
         majorVersion: majorVersion,
         resources: {
-            s3Bucket: [resourcePrefix, 'assets'].join('-'),
+            s3Bucket: _.compact([bucketPrefix, resourcePrefix, 'assets']).join('-'),
             iamRole: [resourcePrefix, 'resource'].join('-'),
             apiGateway: [resourcePrefix, 'api-gateway'].join('-'),
             lambdaVersion: [resourcePrefix, 'lambda-version'].join('-')

--- a/lib/helpers/config.js
+++ b/lib/helpers/config.js
@@ -9,9 +9,7 @@ const _ = require('lodash');
 // Information about LT itself
 const pkg = require('../../package.json');
 const majorVersion = pkg.version ? pkg.version.split('.')[0] : 'unknown';
-const resourcePrefix = _.compact([pkg.name, majorVersion]).join('-');
-
-const bucketPrefix = (new Configstore(pkg.name)).get('S3BucketPrefix');
+const resourcePrefix = _.compact([(new Configstore(pkg.name)).get('ResourcePrefix'), pkg.name, majorVersion]).join('-');
 
 /**
  *  Helper for loading config file of a project
@@ -33,7 +31,7 @@ let result = {
         version: pkg.version,
         majorVersion: majorVersion,
         resources: {
-            s3Bucket: _.compact([bucketPrefix, resourcePrefix, 'assets']).join('-'),
+            s3Bucket: [resourcePrefix, 'assets'].join('-'),
             iamRole: [resourcePrefix, 'resource'].join('-'),
             apiGateway: [resourcePrefix, 'api-gateway'].join('-'),
             lambdaVersion: [resourcePrefix, 'lambda-version'].join('-')

--- a/lib/setup/create-cf-resources.js
+++ b/lib/setup/create-cf-resources.js
@@ -8,6 +8,7 @@
 const AWS = require('aws-sdk');
 const chalk = require('chalk');
 const Promise = require('bluebird');
+const Configstore = require('configstore');
 const path = require('path');
 const dot = require('dot');
 const fs = Promise.promisifyAll(require('graceful-fs'));
@@ -162,7 +163,7 @@ function ensureS3Bucket(bucketName) {
     });
 }
 
-module.exports = function(region) {
+module.exports = function(region, bucketPrefix) {
     // Configure AWS
     if (!region && !AWS.config.region) {
         logger.log(`Defaulting region to ${chalk.underline('us-east-1')}`);
@@ -174,6 +175,13 @@ module.exports = function(region) {
         AWS.config.update({
             region: region
         });
+    }
+
+    // Determine final bucket name
+    let bucketName = [config.tools.resources.s3Bucket, region].join('-');
+    if (bucketPrefix) {
+        logger.log(`Setting bucket prefix to ${chalk.underline(bucketPrefix)}`);
+        bucketName = [bucketPrefix, bucketName].join('-');
     }
 
     // Create a basic role for the Lambda to use
@@ -230,10 +238,13 @@ module.exports = function(region) {
         });
     })
     .then(function() {
-        const bucketName = [config.tools.resources.s3Bucket, region].join('-');
         const task = `Creating S3 bucket: ${chalk.underline(bucketName)}`;
         return logger.task(task, function(resolve, reject) {
             return ensureS3Bucket(bucketName).then(resolve, reject);
+        }).then(function() {
+            logger.log(`Storing bucket prefix configuration as ${chalk.underline(bucketPrefix)}`);
+            const conf = new Configstore(config.tools.name);
+            conf.set('S3BucketPrefix', bucketPrefix);
         });
     });
 };

--- a/lib/setup/create-cf-resources.js
+++ b/lib/setup/create-cf-resources.js
@@ -15,9 +15,10 @@ const fs = Promise.promisifyAll(require('graceful-fs'));
 const fsx = require('../helpers/fs-additions');
 const os = require('os');
 
-const config = require('../helpers/config');
 const logger = require('../helpers/logger').shared;
 const bundler = require('../deploy/bundle-lambdas-step');
+
+const pkg = require('../../package.json');
 
 function ensureLambdaRole(roleName, policyName, region, s3BucketName) {
     const iam = new AWS.IAM();
@@ -163,7 +164,7 @@ function ensureS3Bucket(bucketName) {
     });
 }
 
-module.exports = function(region, bucketPrefix) {
+module.exports = function(region, resourcePrefix) {
     // Configure AWS
     if (!region && !AWS.config.region) {
         logger.log(`Defaulting region to ${chalk.underline('us-east-1')}`);
@@ -178,11 +179,15 @@ module.exports = function(region, bucketPrefix) {
     }
 
     // Determine final bucket name
-    let bucketName = [config.tools.resources.s3Bucket, region].join('-');
-    if (bucketPrefix) {
-        logger.log(`Setting bucket prefix to ${chalk.underline(bucketPrefix)}`);
-        bucketName = [bucketPrefix, bucketName].join('-');
+    if (resourcePrefix) {
+        logger.log(`Setting resource prefix to ${chalk.underline(resourcePrefix)}`);
+        const conf = new Configstore(pkg.name);
+        conf.set('ResourcePrefix', resourcePrefix);
     }
+
+    // Load config (this ensures any changes to resource prefix are correctly loaded)
+    const config = require('../helpers/config');
+    const bucketName = [config.tools.resources.s3Bucket, region].join('-');
 
     // Create a basic role for the Lambda to use
     const name = `Creating lambda execution role ${chalk.underline(config.tools.resources.iamRole)}`;
@@ -241,10 +246,6 @@ module.exports = function(region, bucketPrefix) {
         const task = `Creating S3 bucket: ${chalk.underline(bucketName)}`;
         return logger.task(task, function(resolve, reject) {
             return ensureS3Bucket(bucketName).then(resolve, reject);
-        }).then(function() {
-            logger.log(`Storing bucket prefix configuration as ${chalk.underline(bucketPrefix)}`);
-            const conf = new Configstore(config.tools.name);
-            conf.set('S3BucketPrefix', bucketPrefix);
         });
     });
 };

--- a/lib/setup/create-cf-resources.js
+++ b/lib/setup/create-cf-resources.js
@@ -19,7 +19,7 @@ const config = require('../helpers/config');
 const logger = require('../helpers/logger').shared;
 const bundler = require('../deploy/bundle-lambdas-step');
 
-function ensureLambdaRole(roleName, policyName, region) {
+function ensureLambdaRole(roleName, policyName, region, s3BucketName) {
     const iam = new AWS.IAM();
 
     return new Promise(function(resolve, reject) {
@@ -63,7 +63,7 @@ function ensureLambdaRole(roleName, policyName, region) {
                 RoleName: role.RoleName,
                 PolicyName: policyName,
                 PolicyDocument: template({
-                    s3Bucket: [config.tools.resources.s3Bucket, region].join('-')
+                    s3Bucket: s3BucketName
                 })
             }, function(err) {
                 if (err) return reject(err);
@@ -187,7 +187,7 @@ module.exports = function(region, bucketPrefix) {
     // Create a basic role for the Lambda to use
     const name = `Creating lambda execution role ${chalk.underline(config.tools.resources.iamRole)}`;
     return logger.task(name, function(resolve, reject) {
-        ensureLambdaRole(config.tools.resources.iamRole, 'inline-policy', region).then(function(role) {
+        ensureLambdaRole(config.tools.resources.iamRole, 'inline-policy', region, bucketName).then(function(role) {
             resolve(role);
         }, reject);
     })

--- a/lib/setup/create-cf-resources.js
+++ b/lib/setup/create-cf-resources.js
@@ -179,10 +179,13 @@ module.exports = function(region, resourcePrefix) {
     }
 
     // Determine final bucket name
+    const conf = new Configstore(pkg.name);
     if (resourcePrefix) {
         logger.log(`Setting resource prefix to ${chalk.underline(resourcePrefix)}`);
-        const conf = new Configstore(pkg.name);
         conf.set('ResourcePrefix', resourcePrefix);
+    } else {
+        logger.log(`Removing resource prefix`);
+        conf.delete('ResourcePrefix');
     }
 
     // Load config (this ensures any changes to resource prefix are correctly loaded)

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "cfn-response": "^1.0.1",
     "chalk": "^1.1.3",
     "commander": "^2.9.0",
+    "configstore": "^2.1.0",
     "detective": "^4.3.1",
     "dot": "^1.0.3",
     "envify": "^3.4.0",


### PR DESCRIPTION
- [x] Issue exists - #60 
- [x] Linter passes (`npm run lint`)
- [x] Tests pass (`npm run test`)
- [x] CircleCI build is green
- [x] Documentation is up to date (README + comments)

Brief overview of changes:
- Added a new `p` or `resource-prefix` option to `lambda setup`, this allows prefixing all internal resources used by lambda-tools that are created on AWS (S3 bucket, Lambda function for API Gateway and Lambda function for Lambda Function Versioning).
- Made sure said resource-prefix is appropriately stored in global config-store
- Made sure said resource-prefix is then used by deployment.
- NOTE! Once this is merged, version should be bumped (minor version). Also note, that once setup has been run with a resource-prefix, changing it requires re-running setup.

Testing strategy:
- Run `lambda setup -p <some prefix>`, validate that 3 resources were created (S3 bucket, Lambda function for API Gateway and Lambda function for Lambda Versioning).
- Open a simple lambda-tools service, redeploy (preferably to some test stage) and validate that correct resources were used (files uploaded to appropriate S3 bucket, and custom CF resources for API Gateway instance and Lambda function versions used the correct resources).