### PR TITLE
Feature/ignore timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,8 @@ By default, the event file is assumed to be `event.json` and the timeout is set 
 -h, --help                  output usage information
 -e, --event <file>          Path to the event JSON file, defaults to 'event.json'
 --env, --environment <env>  Environment Variables to embed as key-value pairs
--t, --timeout <timeout>     Timeout value for the Lambda function
+--timeout <timeout>         Timeout value for the Lambda function
+--ignore-timeout            Ignore Lambda function timeout
 --no-color                  Turn off ANSI coloring in output
 ```
 
@@ -291,6 +292,8 @@ The command starts a local server, which parses the API spec (defaults to `./api
 -a, --api-file <file>    Path to Swagger API spec (defaults to "./api.json")
 -e, --environment <env>  Environment Variables to embed as key-value pairs
 --mirror-environment     Mirror the environment visible to lambda-tools in the lambda functions
+--timeout <number>       Timeout value for the Lambda functions (in seconds), overrides any function specific configuration
+--ignore-timeout         Ignore Lambda function timeouts, overrides any function specific configuration
 --no-color               Turn off ANSI coloring in output
 ```
 

--- a/bin/lambda-run.js
+++ b/bin/lambda-run.js
@@ -30,6 +30,8 @@ program
     .option('-a, --api-file <file>', 'Path to Swagger API spec (defaults to "./api.json")', parsePath, path.resolve(cwd, 'api.json'))
     .option('-e, --environment <env>', 'Environment Variables to embed as key-value pairs', parseEnvironment, {})
     .option('--mirror-environment', 'Mirror the environment visible to lambda-tools in the lambda functions')
+    .option('--ignore-timeout', 'Ignore Lambda function timeouts')
+    .option('--timeout <number>', 'Fixed timeout (in seconds) for Lambda functions')
     .option('--no-color', 'Turn off ANSI coloring in output');
 
 program.on('--help', function() {
@@ -47,6 +49,12 @@ program.on('--help', function() {
     console.log();
     console.log('    Run service mirroring current process\' environment variables to Lambda functions');
     console.log('    $ lambda run --mirror-environment');
+    console.log();
+    console.log('    Run service with fixed timeout of 8 seconds for Lambda functions');
+    console.log('    $ lambda run --timeout 8');
+    console.log();
+    console.log('    Run service ignoring any timeouts of Lambda functions');
+    console.log('    $ lambda run --ignore-timeout');
     console.log();
 });
 

--- a/bin/lambda-run.js
+++ b/bin/lambda-run.js
@@ -26,12 +26,12 @@ const cwd = process.cwd();
 //
 
 program
-    .option('-p, --port <number>', 'Port to use locally', 3000)
+    .option('-p, --port <n>', 'Port to use locally', parseInt, 3000)
     .option('-a, --api-file <file>', 'Path to Swagger API spec (defaults to "./api.json")', parsePath, path.resolve(cwd, 'api.json'))
     .option('-e, --environment <env>', 'Environment Variables to embed as key-value pairs', parseEnvironment, {})
     .option('--mirror-environment', 'Mirror the environment visible to lambda-tools in the lambda functions')
     .option('--ignore-timeout', 'Ignore Lambda function timeouts')
-    .option('--timeout <number>', 'Fixed timeout (in seconds) for Lambda functions')
+    .option('--timeout <seconds>', 'Fixed timeout (in seconds) for Lambda functions', parseInt)
     .option('--no-color', 'Turn off ANSI coloring in output');
 
 program.on('--help', function() {

--- a/lib/run/execution-wrapper.js
+++ b/lib/run/execution-wrapper.js
@@ -51,7 +51,6 @@ function parseArgs(args) {
 }
 
 function wrapper(path, handler, evt, context, timeout) {
-    timeout = parseInt(timeout || 6000, 10);
     handler = handler || 'handler';
     evt = evt || {};
     let finished = false;
@@ -59,10 +58,6 @@ function wrapper(path, handler, evt, context, timeout) {
     // Timeout monitoring
     const now = new Date().getTime();
     const deadline = now + timeout;
-
-    const watchdog = setTimeout(function() {
-        context.fail(new Error('Operation timed out'));
-    }, timeout);
 
     // Listen to premature exits
     process.on('beforeExit', function() {
@@ -74,17 +69,14 @@ function wrapper(path, handler, evt, context, timeout) {
     // Create a context object to pass along to the Lambda function
     context = _.assign(context, {
         done: function(error, result) {
-            clearTimeout(watchdog);
             exit(error, result);
         },
 
         succeed: function(result) {
-            clearTimeout(watchdog);
             exit(null, result);
         },
 
         fail: function(error) {
-            clearTimeout(watchdog);
             exit(error, null);
         },
 
@@ -101,11 +93,10 @@ function wrapper(path, handler, evt, context, timeout) {
         // Detect if it uses the callback pattern or not
         if (fn.length === 3) {
             // Callback is used, in our case we will just send out
-            // the result and stop the watchdog, but we will not forcefully
+            // the result, but we will not forcefully
             // exit the process. This should be similar to how Lambda does it,
             // where it naturally then let's the process terminate
             fn(evt, context, function(err, data) {
-                clearTimeout(watchdog);
                 finished = true;
 
                 if (!context.callbackWaitsForEmptyEventLoop) {

--- a/lib/run/execution.js
+++ b/lib/run/execution.js
@@ -85,11 +85,33 @@ module.exports = function *(lambdaPath, event, context, environment, assets) {
                 silent: true
             });
 
+            // We want to keep track of the "result" of the Lambda function
             let result = null;
+
+            // Enforce timeout of the child process (if needed)
+            let watchdog = undefined;
+
+            if (context.timeout) {
+                watchdog = setTimeout(function() {
+                    // If this was fired, the process did not exit on time
+                    // Result should be an error and the process should be killed
+                    result = {
+                        type: 'error',
+                        result: new Error('Execution timed out after ' + context.timeout + ' seconds')
+                    };
+
+                    // SIGTERM (should suffice)
+                    child.kill();
+                }, context.timeout * 1000);
+            }
+
+            // If we receive any messages from the child, then those are
+            // interpreted as results (incl. errors)
             child.on('message', function(res) {
                 result = res;
             });
 
+            // Piping through logging from the child process
             child.stdout.on('data', function(data) {
                 const dateString = moment().format('DD-MM-YYYY HH:mm:ss.SSS');
                 const logString = data.toString().split('\n').join('\n\t\t').trim();
@@ -104,8 +126,10 @@ module.exports = function *(lambdaPath, event, context, environment, assets) {
                 console.log(`\t${chalk.gray('[' + dateString + ' ' + context.awsRequestId + ']')} ERROR: ${chalk.red(logString)}`);
             });
 
+            // Handling the termination of the child process
             child.on('exit', function() {
                 console.log('');
+                clearTimeout(watchdog);
 
                 if (!result) {
                     return reject(new Error('Execution did not produce a result'));

--- a/lib/run/route.js
+++ b/lib/run/route.js
@@ -65,7 +65,16 @@ function lambdaRoute(apiDefinition, program) {
                 if (timeout) {
                     context.timeout = timeout;
                 }
+            }
 
+            // If we need to tweak the timeout
+            // (overrides any potential configuration)
+            if (program.ignoreTimeout) {
+                // Ignored timeouts
+                context.timeout = 0;
+            } else if (program.timeout) {
+                // Fixed timeouts
+                context.timeout = program.timeout;
             }
 
             lambdaPath = path.resolve(lambdaPath, handler);


### PR DESCRIPTION
- [x] Issue exists - #63 
- [x] Linter passes (`npm run lint`)
- [x] Tests pass (`npm run test`)
- [x] CircleCI build is green
- [x] Documentation is up to date (README + comments)

Brief overview of changes:
- Added `--timeout <seconds>` and `--ignore-timeout` options to `lambda run`.
- Modified `--timeout <seconds>` option on `lambda execute` (dropped the shorthand notation and modified the logic) and added `--ignore-timeout` option to the command
- Modified the logic with which Lambda function timeouts worked, previously timeouts were enforced by the process in which the function was running. This could lead to a situation where the function never timed out. Now the timeout is enforced by the main process, which should timeout the child more accurately.