### PR TITLE
fix bug of function versions not being retrieved if more than 1 page

### DIFF
--- a/lib/cf-resources/lambda-version-resource/index.js
+++ b/lib/cf-resources/lambda-version-resource/index.js
@@ -40,7 +40,7 @@ function getFunctionVersions(name, marker) {
             // Check if we can grab even more
             if (data.NextMarker) {
                 return getFunctionVersions(name, data.NextMarker).then((versions) => {
-                    return data.Versions.concat(versions);
+                    resolve(data.Versions.concat(versions));
                 });
             }
 


### PR DESCRIPTION
- [x] Linter passes (`npm run lint`)
- [x] Tests pass (`npm run test`)
- [x] CircleCI build is green
- [x] Documentation is up to date (README + comments)

Brief overview of changes:
- Previously the deploy started failing in the case if any lambda reached version count higher than 50. This PR fixes that bug.