### PR TITLE
Feature/add suffix support/grey 1780

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The actions the user executing the scripts should be able to perform are:
 
 This step should only ever be run once for AWS account, region and LT version combination. The step will create the necessary Lambda functions that act as the CloudFormation resources for all stacks created by lambda-tools. If no region is defined, `us-east-1` is assumed. This also creates the staging S3 bucket that is used to store all stack assets. **If this step is not done, all deployments will fail**.
 
-Since the deployed Lambda code is held in S3 buckets and S3 bucket names must be unique across all accounts, deploys will fail unless you provide an unique resource name prefix when running the `setup` command via the resource prefix option described below.
+Since the deployed Lambda code is held in S3 buckets and S3 bucket names must be unique across all accounts, deploys will fail unless you provide an unique resource name prefix/suffix when running the `setup` command via the resource prefix/suffix option described below.
 
 ```
 lambda setup [options]
@@ -112,6 +112,7 @@ lambda setup [options]
 -h, --help                      output usage information
 -r, --region <string>           Region to setup in, if not set otherwise, defaults to 'us-east-1'
 -p, --resource-prefix <string>  Prefix to use with all lambda-tools created AWS resources, defaults to '' (empty string)
+-s, --resource-suffix <string>  Suffix to use with all lambda-tools created AWS resources, defaults to '' (empty string)
 --no-color                      Turn off ANSI coloring in output
 ```
 

--- a/bin/lambda-setup.js
+++ b/bin/lambda-setup.js
@@ -14,11 +14,12 @@ const createResources = require('../lib/setup/create-cf-resources.js');
 program
     .option('-r, --region <string>', 'Region to setup in, if not set otherwise, defaults to \'us-east-1\'')
     .option('-p, --resource-prefix <string>', 'Prefix to use with all lambda-tools created AWS resources, defaults to \'\' (empty string)')
+    .option('-s, --resource-suffix <string>', 'Suffix to use with all lambda-tools created AWS resources, defaults to \'\' (empty string)')
     .option('--no-color', 'Turn off ANSI coloring in output')
     .parse(process.argv);
 
 chalk.enabled = program.color;
 
 logger.task(`Setting up ${chalk.underline('lambda-tools')}`, function(resolve, reject) {
-    createResources(program.region, program.resourcePrefix).then(resolve, reject);
+    createResources(program.region, program.resourcePrefix, program.resourceSuffix).then(resolve, reject);
 });

--- a/lib/helpers/config.js
+++ b/lib/helpers/config.js
@@ -8,8 +8,9 @@ const _ = require('lodash');
 
 // Information about LT itself
 const pkg = require('../../package.json');
+const conf = new Configstore(pkg.name);
 const majorVersion = pkg.version ? pkg.version.split('.')[0] : 'unknown';
-const resourcePrefix = _.compact([(new Configstore(pkg.name)).get('ResourcePrefix'), pkg.name, majorVersion]).join('-');
+const resourceNamePrefix = _.compact([conf.get('ResourcePrefix'), pkg.name, majorVersion, conf.get('ResourceSuffix')]).join('-');
 
 /**
  *  Helper for loading config file of a project
@@ -31,10 +32,10 @@ let result = {
         version: pkg.version,
         majorVersion: majorVersion,
         resources: {
-            s3Bucket: [resourcePrefix, 'assets'].join('-'),
-            iamRole: [resourcePrefix, 'resource'].join('-'),
-            apiGateway: [resourcePrefix, 'api-gateway'].join('-'),
-            lambdaVersion: [resourcePrefix, 'lambda-version'].join('-')
+            s3Bucket: [resourceNamePrefix, 'assets'].join('-'),
+            iamRole: [resourceNamePrefix, 'resource'].join('-'),
+            apiGateway: [resourceNamePrefix, 'api-gateway'].join('-'),
+            lambdaVersion: [resourceNamePrefix, 'lambda-version'].join('-')
         }
     }
 };

--- a/lib/setup/create-cf-resources.js
+++ b/lib/setup/create-cf-resources.js
@@ -164,7 +164,7 @@ function ensureS3Bucket(bucketName) {
     });
 }
 
-module.exports = function(region, resourcePrefix) {
+module.exports = function(region, resourcePrefix, resourceSuffix) {
     // Configure AWS
     if (!region && !AWS.config.region) {
         logger.log(`Defaulting region to ${chalk.underline('us-east-1')}`);
@@ -186,6 +186,13 @@ module.exports = function(region, resourcePrefix) {
     } else {
         logger.log(`Removing resource prefix`);
         conf.delete('ResourcePrefix');
+    }
+    if (resourceSuffix) {
+        logger.log(`Setting resource suffix to ${chalk.underline(resourceSuffix)}`);
+        conf.set('ResourceSuffix', resourceSuffix);
+    } else {
+        logger.log(`Removing resource suffix`);
+        conf.delete('ResourceSuffix');
     }
 
     // Load config (this ensures any changes to resource prefix are correctly loaded)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lambda-tools",
-  "version": "3.5.2",
+  "version": "3.5.3",
   "description": "Scripts for working with AWS Lambda backed microservices",
   "main": "",
   "scripts": {
@@ -66,7 +66,7 @@
     "velocityjs": "^0.7.5"
   },
   "resolutions": {
-      "graceful-fs": "4.1.9"
+    "graceful-fs": "4.1.9"
   },
   "devDependencies": {
     "eslint": "^5.15.1"


### PR DESCRIPTION
_Before submitting the PR, make sure all of the following boxes are checked - thank you!_

- [x] Issue exists - [GREY-1780](https://testlions.atlassian.net/browse/GREY-1780)
- [x] Linter passes (`npm run lint`)
- [x] Tests pass (`npm run test`)
- [x] CircleCI build is green
- [x] Documentation is up to date (README + comments)

Brief overview of changes:
- Added suffix based support for creating lambda-tools resources
![](<feel free to include a suitable Giphy>)
