### PR TITLE
OPS-98: Fix TooManyRequestsException deployment failures for larger services

### DIFF
--- a/lib/cf-resources/lambda-version-resource/index.js
+++ b/lib/cf-resources/lambda-version-resource/index.js
@@ -19,6 +19,7 @@ function getRandomInt(max) {
  * @return {Promise} which resolves into the function configuration
  */
 function getFunction(name) {
+    console.log('[getFunction]', name);
     return new Promise((resolve, reject) => {
         lambda.getFunctionConfiguration({
             FunctionName: name
@@ -36,6 +37,7 @@ function getFunction(name) {
  */
 function getFunctionVersions(name, marker) {
     // Grab functions
+    console.log('[getFunctionVersions]', name);
     return new Promise((resolve, reject) => {
         lambda.listVersionsByFunction({
             FunctionName: name,
@@ -61,6 +63,7 @@ function getFunctionVersions(name, marker) {
  * @return {Promise} which resolves into the newly published version
  */
 function functionPublishVersion(name, description, hash) {
+    console.log('[functionPublishVersion]', name);
     return new Promise((resolve, reject) => {
         lambda.publishVersion({
             FunctionName: name,
@@ -100,21 +103,23 @@ exports.handler = function(event, context) {
         return response.send(event, context, response.SUCCESS, {});
     }
 
-    // Grab the function first
-    getFunction(properties.FunctionName).then(function(fn) {
-        // Then grab all versions
-        return getFunctionVersions(fn.FunctionName).then((versions) => {
-            // Try to find one that matches the function configuration
-            versions = versions.filter((version) => {
-                // Ignore the latest pseudo-version
-                return version.Version !== '$LATEST';
-            });
+    delay(getRandomInt(15000)).then(() => {
+        // Grab the function first
+        return getFunction(properties.FunctionName).then(function(fn) {
+            // Then grab all versions
+            return getFunctionVersions(fn.FunctionName).then((versions) => {
+                // Try to find one that matches the function configuration
+                versions = versions.filter((version) => {
+                    // Ignore the latest pseudo-version
+                    return version.Version !== '$LATEST';
+                });
 
-            const trimmedFn = _.pick(fn, 'LastModified');
-            return {
-                fn: fn,
-                version: _.find(versions, trimmedFn)
-            };
+                const trimmedFn = _.pick(fn, 'LastModified');
+                return {
+                    fn: fn,
+                    version: _.find(versions, trimmedFn)
+                };
+            });
         });
     }).then((results) => {
         return delay(getRandomInt(5000)).then(function() {

--- a/lib/cf-resources/lambda-version-resource/index.js
+++ b/lib/cf-resources/lambda-version-resource/index.js
@@ -19,7 +19,7 @@ function getRandomInt(max) {
  * @return {Promise} which resolves into the function configuration
  */
 function getFunction(name) {
-    console.log('[getFunction]', name);
+    console.log('Function name: ', name);
     return new Promise((resolve, reject) => {
         lambda.getFunctionConfiguration({
             FunctionName: name
@@ -37,7 +37,7 @@ function getFunction(name) {
  */
 function getFunctionVersions(name, marker) {
     // Grab functions
-    console.log('[getFunctionVersions]', name);
+    console.log('Function versions: ', name);
     return new Promise((resolve, reject) => {
         lambda.listVersionsByFunction({
             FunctionName: name,
@@ -63,7 +63,7 @@ function getFunctionVersions(name, marker) {
  * @return {Promise} which resolves into the newly published version
  */
 function functionPublishVersion(name, description, hash) {
-    console.log('[functionPublishVersion]', name);
+    console.log('Publishing function version: ', name);
     return new Promise((resolve, reject) => {
         lambda.publishVersion({
             FunctionName: name,

--- a/lib/cf-resources/lambda-version-resource/index.js
+++ b/lib/cf-resources/lambda-version-resource/index.js
@@ -103,6 +103,7 @@ exports.handler = function(event, context) {
         return response.send(event, context, response.SUCCESS, {});
     }
 
+    // Artificial delay to prevent deploys from hitting internal AWS API limits
     delay(getRandomInt(15000)).then(() => {
         // Grab the function first
         return getFunction(properties.FunctionName).then(function(fn) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lambda-tools",
-  "version": "3.5.5",
+  "version": "3.5.7",
   "description": "Scripts for working with AWS Lambda backed microservices",
   "main": "",
   "scripts": {


### PR DESCRIPTION
- [x] Issue exists - [OPS-98](https://testlions.atlassian.net/browse/OPS-98)
- [x] Linter passes (`npm run lint`)
- [x] Tests pass (`npm run test`)
- [x] CircleCI build is green
- [x] Documentation is up to date (README + comments)

Brief overview of changes:
- Adding artificial delays to lambda version API calls (0s-14s random)
- Needed to prevent larger services hitting internal AWS API limits, resulting in deployment failures by `TooManyRequestsException`
