### PR TITLE
add native escape function for velocity templates

### DIFF
--- a/lib/helpers/api-gateway-mapping-parser.js
+++ b/lib/helpers/api-gateway-mapping-parser.js
@@ -30,6 +30,10 @@ module.exports = function(template, params, context, payload, stageVariables) {
                 return _.isString(value) ? value.replace(/\\([\s\S])|(")/g, "\\$1$2") : null;
             },
 
+            escape: function(value) {
+                return _.isString(value) ? escape(value) : null;
+            },
+
             parseJson: function(string) {
                 return JSON.parse(string);
             },


### PR DESCRIPTION
Usage: 

```
"requestTemplates": {
    "application/json": "{\"foo\":\"$util.escape($input.params('foo'))\"}"
}
```